### PR TITLE
Parse error fix

### DIFF
--- a/src/Symfony/Component/HttpKernel/Cache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/Cache/Esi.php
@@ -176,7 +176,7 @@ class Esi
             $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
 
             if (200 != $response->getStatusCode()) {
-                throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $request->getUri(), $response->getStatusCode()));
+                throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $subRequest->getUri(), $response->getStatusCode()));
             }
 
             return $response->getContent();


### PR DESCRIPTION
Un nom de variable était incorrect dans la classe Esi. 
