### PR TITLE
Allow auto escaping to be disabled in TwigBundle

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -44,6 +44,16 @@ class TwigExtension extends Extension
                 $container->setParameter('twig.form.resources', array_merge($container->getParameter('twig.form.resources'), $resources));
             }
         }
+
+        // escaper extension
+        if (array_key_exists('escaper', $config)) {
+            if ($config['escaper']===null) {
+                // Disable escaper extension
+                $container->remove('twig.extension.escaper');
+            } else {
+                $container->setParameter('twig.escaper.auto', $config['escaper']);
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
@@ -18,6 +18,7 @@
         <xsd:attribute name="trim_blocks" type="xsd:string" />
         <xsd:attribute name="auto_reload" type="xsd:string" />
         <xsd:attribute name="base_template_class" type="xsd:string" />
+        <xsd:attribute name="escaper" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="form">

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -14,6 +14,7 @@
         <parameter key="twig.loader.class">Symfony\Bundle\TwigBundle\Loader\Loader</parameter>
         <parameter key="twig.renderer.class">Symfony\Bundle\TwigBundle\Renderer\Renderer</parameter>
         <parameter key="twig.form.resources" type="collection"></parameter>
+        <parameter key="twig.escaper.auto">true</parameter>
     </parameters>
 
     <services>
@@ -36,6 +37,7 @@
 
         <service id="twig.extension.escaper" class="Twig_Extension_Escaper">
             <tag name="twig.extension" />
+            <argument>%twig.escaper.auto%</argument>
         </service>
 
         <service id="twig.extension.trans" class="Symfony\Bundle\TwigBundle\Extension\TransExtension">

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -30,4 +30,13 @@ class TwigExtensionTest extends TestCase
         $this->assertEquals('ISO-8859-1', $options['charset'], '->configLoad() overrides existing configuration options');
         $this->assertEquals('%kernel.debug%', $options['debug'], '->configLoad() merges the new values with the old ones');
     }
+
+    public function testDisableEscaper()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TwigExtension();
+
+        $loader->configLoad(array('escaper' => null), $container);
+        $this->assertFalse($container->has('twig.extension.escaper'), '->configLoad() disables the escaper extension if escaper set to null');
+    }
 }


### PR DESCRIPTION
This adds support for enabling/disabling auto-escaping in the TwigBundle as well as the entire escaper extension.  The escaper extension must be explicitly enabled via the app's config:

```
# config/config.yml:
twig.config: ~
twig.escaper: ~
```

When the escaper extension is enabled, auto escaping is still on by default.  To disable it:

```
# config/config.yml:
twig.config: ~
twig.escaper:
  auto: false
```

If you pull this, you might also want to grab these symfony-docs changes:
blt04/symfony-docs@b397b819b7dd5c93db1135534fcc6329f06dcb68 (I can send a pull request if that is easier)

Thoughts?
