### PR TITLE
Min max validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/MaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxValidator.php
@@ -14,11 +14,16 @@ class MaxValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_numeric($value)) {
+        if (!is_numeric($value) && !$value instanceof \DateTime) {
             throw new UnexpectedTypeException($value, 'numeric');
         }
 
         if ($value > $constraint->limit) {
+            if ($value instanceof \DateTime) {
+                $value = $value->format('Y-m-d H:i:s');
+                $constraint->limit = $constraint->limit->format('Y-m-d H:i:s');
+            }
+	
             $this->setMessage($constraint->message, array(
                 'value' => $value,
                 'limit' => $constraint->limit,

--- a/src/Symfony/Component/Validator/Constraints/MinValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinValidator.php
@@ -14,11 +14,16 @@ class MinValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_numeric($value)) {
+        if (!is_numeric($value) && !$value instanceof \DateTime) {
             throw new UnexpectedTypeException($value, 'numeric');
         }
 
         if ($value < $constraint->limit) {
+            if ($value instanceof \DateTime) {
+                $value = $value->format('Y-m-d H:i:s');
+                $constraint->limit = $constraint->limit->format('Y-m-d H:i:s');
+            }
+	
             $this->setMessage($constraint->message, array(
                 'value' => $value,
                 'limit' => $constraint->limit,

--- a/tests/Symfony/Tests/Component/Validator/Constraints/MaxValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/MaxValidatorTest.php
@@ -76,4 +76,18 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
             'limit' => 10,
         ));
     }
+
+    public function testDateTimeCanBeUsed()
+    {
+        $dateBefore = new \DateTime('2010-10-18 04:20:00');
+        $dateMax 	= new \DateTime('2010-10-19 04:20:00');
+        $dateAfter 	= new \DateTime('2010-10-20 04:20:00');
+
+        $constraint = new Max(array(
+            'limit' => $dateMax
+        ));
+
+        $this->assertTrue($this->validator->isValid($dateBefore, $constraint));
+        $this->assertFalse($this->validator->isValid($dateAfter, $constraint));
+    }
 }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/MinValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/MinValidatorTest.php
@@ -76,4 +76,18 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
             'limit' => 10,
         ));
     }
+
+    public function testDateTimeCanBeUsed()
+    {
+        $dateBefore = new \DateTime('2010-10-18 04:20:00');
+        $dateMax 	= new \DateTime('2010-10-19 04:20:00');
+        $dateAfter 	= new \DateTime('2010-10-20 04:20:00');
+
+        $constraint = new Max(array(
+            'limit' => $dateMax
+        ));
+
+        $this->assertFalse($this->validator->isValid($dateBefore, $constraint));
+        $this->assertTrue($this->validator->isValid($dateAfter, $constraint));
+    }
 }


### PR DESCRIPTION
Now we can use DateTime comparaison for Min and Max validator

<pre>
$dateMax      = new DateTime('2010-10-19');
$dateAfterMax = new DateTime('2010-10-20');

$constraint = new Max(array('limit' => $dateMax));

echo $validator->isValid($constraint, $dateAfterMax); // false
echo $dateMax > $dateAfterMax; // false</pre>


It can be usefull if i have for example an holiday reservation with a <b>start</b> and a <b>end</b>.

<ul>
<li><b>start</b> is before <b>end</b></li>
<li><b>start</b> is after <u>today</u></li>
<li><b>end</b> is after <u>today</u></li>
<li><b>end</b> not equal to <b>start</b> <i>(we have to create an Equal and NotEqual validator)</i></li>
</ul>
