### PR TITLE
Fix namespace conflict

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Client as BaseClient;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\CookieJar;
-use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\HttpKernel\Profiler\Profiler as HttpProfiler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -67,7 +67,7 @@ class Client extends BaseClient
     /**
      * Gets a profiler for the current Response.
      *
-     * @return Profiler A Profiler instance
+     * @return HttpProfiler A Profiler instance
      */
     public function getProfiler()
     {


### PR DESCRIPTION
Fixes an error when running functional tests:

```
RuntimeException: PHP Fatal error:  Cannot use Symfony\Component\HttpKernel\Profiler\Profiler as Profiler because the name is already in use in ***/src/vendor/symfony/src/Symfony/Bundle/FrameworkBundle/Client.php on line 10
```
