### PR TITLE
Fix FieldGroup::getHiddenFields

### DIFF
--- a/src/Symfony/Component/Form/FieldGroup.php
+++ b/src/Symfony/Component/Form/FieldGroup.php
@@ -261,7 +261,7 @@ class FieldGroup extends Field implements \IteratorAggregate, FieldGroupInterfac
                 if ($recursive) {
                     $fields = array_merge($fields, $field->getFieldsByVisibility($hidden, $recursive));
                 }
-            } else if (($hidden && $field->isHidden()) || !$field->isHidden()) {
+            } else if ((bool)$hidden === $field->isHidden()) {
                 $fields[] = $field;
             }
         }

--- a/tests/Symfony/Tests/Component/Form/FieldGroupTest.php
+++ b/tests/Symfony/Tests/Component/Form/FieldGroupTest.php
@@ -603,6 +603,50 @@ class FieldGroupTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('firstName' => 'Bernhard'), $group->getData());
     }
 
+    public function testGetHiddenFieldsReturnsOnlyHiddenFields()
+    {
+        $group = $this->getGroupWithBothVisibleAndHiddenField();
+
+        $hiddenFields = $group->getHiddenFields(true, false);
+
+        $this->assertSame(array($group['hiddenField']), $hiddenFields);
+    }
+
+    public function testGetVisibleFieldsReturnsOnlyVisibleFields()
+    {
+        $group = $this->getGroupWithBothVisibleAndHiddenField();
+
+        $visibleFields = $group->getVisibleFields(true, false);
+
+        $this->assertSame(array($group['visibleField']), $visibleFields);
+    }
+
+    /**
+     * Create a group containing two fields, "visibleField" and "hiddenField"
+     *
+     * @return FieldGroup
+     */
+    protected function getGroupWithBothVisibleAndHiddenField()
+    {
+        $group = new FieldGroup('testGroup');
+
+        // add a visible field
+        $visibleField = $this->createMockField('visibleField');
+        $visibleField->expects($this->once())
+                    ->method('isHidden')
+                    ->will($this->returnValue(false));
+        $group->add($visibleField);
+
+        // add a hidden field
+        $hiddenField = $this->createMockField('hiddenField');
+        $hiddenField->expects($this->once())
+                    ->method('isHidden')
+                    ->will($this->returnValue(true));
+        $group->add($hiddenField);
+
+        return $group;
+    }
+
     protected function createMockField($key)
     {
         $field = $this->getMock(


### PR DESCRIPTION
I added 2 unit tests for `FieldGroup::getVisibleFields` and `FieldGroup::getHiddenFields`.
This commit also includes a fix for `FieldGroup::getHiddenFields` that makes the test pass.
