### PR TITLE
Fix twig collection field rendering

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
@@ -5,6 +5,7 @@ namespace Symfony\Bundle\TwigBundle\Extension;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FieldGroupInterface;
 use Symfony\Component\Form\FieldInterface;
+use Symfony\Component\Form\CollectionField;
 use Symfony\Bundle\TwigBundle\TokenParser\FormThemeTokenParser;
 use Symfony\Bundle\FrameworkBundle\Templating\HtmlGeneratorInterface;
 
@@ -96,6 +97,13 @@ class FormExtension extends \Twig_Extension
         if ($field instanceof Form || get_class($field) === 'Symfony\Component\Form\FieldGroup') {
             return $this->templates['group']->getBlock('group', array(
                 'group'      => $field,
+                'attributes' => $attributes,
+            ));
+        }
+
+        if ($field instanceof CollectionField) {
+            return $this->templates['group']->getBlock('collection', array(
+                'collection' => $field,
                 'attributes' => $attributes,
             ));
         }

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/form.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/form.twig
@@ -20,6 +20,14 @@
     </tr>
 {% endblock field %}
 
+{% block collection %}
+    <table>
+        {% for field in collection %}
+            {{ field|render }}
+        {% endfor %}
+    </table>
+{% endblock collection %}
+
 {% block errors %}
     {% if errors %}
     <ul>


### PR DESCRIPTION
As for now when rendering a form that contains a CollectionField, we get a endless loop.
This commit adds a twig block to render CollectionFields.
