### PR TITLE
Routing ressource root url

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -100,7 +100,11 @@ class RouteCollection
         }
 
         foreach ($this->getRoutes() as $route) {
-            $route->setPattern($prefix.$route->getPattern());
+            if($route->getPattern() == '/') {
+                $route->setPattern($prefix);
+            } else {
+                $route->setPattern($prefix.$route->getPattern());
+            }
         }
     }
 


### PR DESCRIPTION
There is a bug with the RouteCollection::addPrefix. With the current implementation the router will generate the route `shortener_index` with the following route : `/s/`. however this is wrong, the value must be `/s`

<pre>
urlshortener:
    resource: UrlShortenerBundle/Resources/config/routing/urlshortener.yml
    prefix: /s
</pre>


urlshortener.yml

<pre>
shortener_index:
    pattern:  /
    defaults: { _controller: UrlShortenerBundle:UrlShortener:index }
</pre>
