### PR TITLE
Twig include fix

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/HelpersExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/HelpersExtension.php
@@ -63,6 +63,9 @@ class HelpersExtension extends \Twig_Extension
 
             // {% flash 'notice' %}
             new HelperTokenParser('flash', '<name>', 'templating.helper.session', 'getFlash'),
+
+            // {% include 'sometemplate.php' with ['something' : 'something2'] %}
+            new HelperTokenParser('include', '<name> [with <arguments:array>]', 'templating.engine', 'render'),
         );
     }
 


### PR DESCRIPTION
Currently the {% include %} tag provided by Twig_CoreExtension is broken in Symfony2 because the TwigBundle\Loader\Loader.php will just get the .php template and send it to twig which will make it into a __Twig_Template_Class with a display() method.

This makes the include tag unable to be used with other template renderers than .twig.

The fixes it by sending {% include 'notation' with ['arg' : 'value'] %} to the Template Components render() method by overriding the NodeToken in HelpersExtension in TwigBundle.

Proberly a very bad explanaition.
