### PR TITLE
Allow multiple routing requirement with xml loader

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -95,17 +95,7 @@ class XmlFileLoader extends FileLoader
                     $options[(string) $node->getAttribute('key')] = trim((string) $node->nodeValue);
                     break;
                 case 'requirement':
-                    if('collection' === $node->getAttribute('type')) {
-                        $requirement = array();
-                        foreach($node->childNodes as $requirementNode) {
-                            if ($requirementNode instanceof \DOMElement) {
-                                $requirement[] = $requirementNode->nodeValue;
-                            }
-                        }
-                    }
-                    else {
-                        $requirement = trim((string) $node->nodeValue);
-                    }
+                    $requirement = explode(',', trim((string) $node->nodeValue));
                     $requirements[(string) $node->getAttribute('key')] = $requirement;
                     break;
                 default:

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -17,7 +17,7 @@
   <xsd:complexType name="route">
     <xsd:sequence>
       <xsd:element name="default" type="element" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="requirement" type="requirement" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="requirement" type="element" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="option" type="element" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
 
@@ -34,19 +34,4 @@
   <xsd:complexType name="element" mixed="true">
     <xsd:attribute name="key" type="xsd:string" />
   </xsd:complexType>
-
-  <xsd:complexType name="requirement" mixed="true">
-    <xsd:sequence>
-      <xsd:element name="requirement" type="element" minOccurs="0" maxOccurs="unbounded" />
-    </xsd:sequence>
-    <xsd:attribute name="type" type="requirement_type" />
-    <xsd:attribute name="key" type="xsd:string" />
-  </xsd:complexType>
-
-  <xsd:simpleType name="requirement_type">
-    <xsd:restriction base="xsd:string">
-      <xsd:enumeration value="collection" />
-    </xsd:restriction>
-  </xsd:simpleType>
-
 </xsd:schema>


### PR DESCRIPTION
As for now it's impossible to make a route match both GET and HEAD methods using the XML routing loader:

```
<route id="foo_route" pattern="/foo/pattern">
    <default key="_controller">FooBundle:Bar:index</default>
    <requirement key="_method" type="collection">
        <requirement>GET</requirement>
        <requirement>HEAD</requirement>
    </requirement>
</route>
```

It does not work. This commit fixes that by allowing requirements of type collection.
