### PR TITLE
Twig security fix

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/SecurityExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/SecurityExtension.php
@@ -22,7 +22,7 @@ class SecurityExtension extends \Twig_Extension
 {
     protected $context;
 
-    public function __construct(SecurityContext $context)
+    public function __construct(SecurityContext $context = null)
     {
         $this->context = $context;
     }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -61,7 +61,7 @@
 
         <service id="twig.security.form" class="Symfony\Bundle\TwigBundle\Extension\SecurityExtension">
             <tag name="twig.extension" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.context" on-invalid="ignore" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Fixed the SecurityExtension so that Twig can be used without having the Security Component enabled.

(hopefully this went well kinda f'ed my git repository up a bit)
