### PR TITLE
XmlFileLoader should allow "factory-service" attribute without "class" for <service>

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -105,9 +105,9 @@ class XmlFileLoader extends FileLoader
             return;
         }
 
-        $definition = new Definition((string) $service['class']);
+        $definition = new Definition();
 
-        foreach (array('shared', 'factory-method', 'factory-service', 'factory-class') as $key) {
+        foreach (array('class', 'shared', 'factory-method', 'factory-service') as $key) {
             if (isset($service[$key])) {
                 $method = 'set'.str_replace('-', '', $key);
                 $definition->$method((string) $service->getAttributeAsPhp($key));

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
@@ -139,6 +139,8 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(array('setBar', array())), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
+        $this->assertNull($services['factory_service']->getClass());
+        $this->assertEquals('getInstance', $services['factory_service']->getFactoryMethod());
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
 
         $aliases = $container->getAliases();


### PR DESCRIPTION
Also removed obsolete "factory-class" attribute.
