### PR TITLE
[HttpKernel] fixed typo at Security\Firewall\DigestAuthenticationListener

### DIFF
--- a/src/Symfony/Component/HttpKernel/Security/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/DigestAuthenticationListener.php
@@ -210,7 +210,7 @@ class DigestData
         } elseif ('auth' === $this->elements['qop']) {
             $digest .= ':'.$this->elements['nc'].':'.$this->elements['cnonce'].':'.$this->elements['qop'];
         } else {
-            throw new \IllegalArgumentException('This method does not support a qop: "%s".', $this->elements['qop']);
+            throw new \InvalidArgumentException('This method does not support a qop: "%s".', $this->elements['qop']);
         }
         $digest .= ':'.$a2Md5;
 


### PR DESCRIPTION
Fixed the missing class `IllegualArgumentException` to `InvalidArgumentException`
