### PR TITLE
Base form templates adjustment

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/form.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/form.twig
@@ -1,31 +1,27 @@
 {% block group %}
     {{ group|render_errors }}
-    <table>
-        {% for field in group %}
-            {% if not field.ishidden %}
-                {{ field|render }}
-            {% endif %}
-        {% endfor %}
-    </table>
+    {% for field in group %}
+        {% if not field.ishidden %}
+            {{ field|render }}
+        {% endif %}
+    {% endfor %}
     {{ group|render_hidden }}
 {% endblock group %}
 
 {% block field %}
-    <tr>
-        <th>{{ field|render_label }}</th>
-        <td>
-            {{ field|render_errors }}
-            {{ field|render_widget }}
-        </td>
-    </tr>
+    <div>
+        {{ field|render_label }}
+        {{ field|render_errors }}
+        {{ field|render_widget }}
+    </div>
 {% endblock field %}
 
 {% block collection %}
-    <table>
+    <div>
         {% for field in collection %}
             {{ field|render }}
         {% endfor %}
-    </table>
+    </div>
 {% endblock collection %}
 
 {% block errors %}


### PR DESCRIPTION
Tables don't really make sense for forms that aren't tabular data. ul/li work well for most people, and also the default should match the best practice for bundle devs imo. I'll send a mail to the ml shortly about this.
