### PR TITLE
Allows for empty "routes" nodes in xml routing

### DIFF
--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -8,7 +8,7 @@
   <xsd:element name="routes" type="routes" />
 
   <xsd:complexType name="routes">
-    <xsd:choice maxOccurs="unbounded">
+    <xsd:choice maxOccurs="unbounded" minOccurs="0">
       <xsd:element name="import" type="import" />
       <xsd:element name="route" type="route" />
     </xsd:choice>


### PR DESCRIPTION
Hey Fabien-

Very minor. This allows Symfony to continue in the event that a "routes" xml node is empty. This shouldn't be a normal situation, but the lack of an import or route child node doesn't seem like a violation of the xml schema.

As always, thoughts welcomed.

Thanks
