### PR TITLE
Pass encoding

### DIFF
--- a/src/Symfony/Component/Security/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Encoder/BasePasswordEncoder.php
@@ -24,23 +24,20 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      * @param string $mergedPasswordSalt The merged password and salt string
      *
      * @return array An array where the first element is the password and the second the salt
+     *
+     * @throws \InvalidArgumentException When the merged password and salt use an invalid format
      */
     protected function demergePasswordAndSalt($mergedPasswordSalt)
     {
-        if (empty($mergedPasswordSalt)) {
-            return array('', '');
+        $level = error_reporting(0);
+        $passwordSalt = unserialize($mergedPasswordSalt);
+        error_reporting($level);
+
+        if ($passwordSalt === false) {
+            throw new \InvalidArgumentException('Invalid format used for merged password and salt.');
         }
 
-        $password = $mergedPasswordSalt;
-        $salt = '';
-        $saltBegins = strrpos($mergedPasswordSalt, '{');
-
-        if (false !== $saltBegins && $saltBegins + 1 < strlen($mergedPasswordSalt)) {
-            $salt = substr($mergedPasswordSalt, $saltBegins + 1, -1);
-            $password = substr($mergedPasswordSalt, 0, $saltBegins);
-        }
-
-        return array($password, $salt);
+        return $passwordSalt;
     }
 
     /**
@@ -53,15 +50,7 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      */
     protected function mergePasswordAndSalt($password, $salt)
     {
-        if (empty($salt)) {
-            return $password;
-        }
-
-        if (false !== strrpos($salt, '{') || false !== strrpos($salt, '}')) {
-            throw new \InvalidArgumentException('Cannot use { or } in salt.');
-        }
-
-        return $password.'{'.$salt.'}';
+        return serialize(array($password, $salt));
     }
 
     /**


### PR DESCRIPTION
Allow any character in the salt (`{`, `}` were forbidden before).
