### PR TITLE
Allow different prefix for similar namespace in class loader

### DIFF
--- a/src/Symfony/Component/HttpFoundation/UniversalClassLoader.php
+++ b/src/Symfony/Component/HttpFoundation/UniversalClassLoader.php
@@ -132,13 +132,11 @@ class UniversalClassLoader
             $namespace = substr($class, 0, $pos);
             foreach ($this->namespaces as $ns => $dir) {
                 if (0 === strpos($namespace, $ns)) {
-                    $class = substr($class, $pos + 1);
-                    $file = $dir.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $namespace).DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $class).'.php';
+                    $file = $dir.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $namespace).DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, substr($class, $pos + 1)).'.php';
                     if (file_exists($file)) {
                         require $file;
+                        return;
                     }
-
-                    return;
                 }
             }
         } else {
@@ -148,9 +146,8 @@ class UniversalClassLoader
                     $file = $dir.DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $class).'.php';
                     if (file_exists($file)) {
                         require $file;
+                        return;
                     }
-
-                    return;
                 }
             }
         }

--- a/tests/Symfony/Tests/Component/HttpFoundation/Fixtures/Extension/Namespaced/Foo/ExtensionBar.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/Fixtures/Extension/Namespaced/Foo/ExtensionBar.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Namespaced\Foo;
+
+class ExtensionBar {
+	public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/HttpFoundation/Fixtures/Namespaced/Foo/Bar.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/Fixtures/Namespaced/Foo/Bar.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Namespaced\Foo;
+
+class Bar {
+	public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/HttpFoundation/UniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/UniversalClassLoaderTest.php
@@ -23,6 +23,7 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $loader = new UniversalClassLoader();
         $loader->registerNamespace('Namespaced', __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures');
+        $loader->registerNamespace('Namespaced\\Foo', __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures/Extension');
         $loader->registerPrefix('Pearlike_', __DIR__ . DIRECTORY_SEPARATOR . 'Fixtures');
         $loader->loadClass($testClassName);
         $this->assertTrue(class_exists($className), $message);
@@ -35,6 +36,8 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
             array('\\Pearlike_Foo',    'Pearlike_Foo',      '->loadClass() loads Pearlike_Foo class'),
             array('\\Namespaced\\Bar', '\\Namespaced\\Bar', '->loadClass() loads Namespaced\Bar class with a leading slash'),
             array('\\Pearlike_Bar',    '\\Pearlike_Bar',    '->loadClass() loads Pearlike_Bar class with a leading slash'),
+            array('\\Namespaced\\Foo\\Bar', 'Namespaced\\Foo\\Bar',   '->loadClass() loads Namespaced\Foo\Bar class'),
+            array('\\Namespaced\\Foo\\ExtensionBar', 'Namespaced\\Foo\\ExtensionBar',   '->loadClass() loads Namespaced\Foo\ExtensionBar class'),
         );
     }
 }


### PR DESCRIPTION
Here is an example to understand what this commit is about:

Zend provides Zend\Cache\Backend\Memcached.
We want to add a new cache backend called Zend\Cache\Backend\Custom.
We must keep the Zend\Cache\Backend namespace, but we can't of course
put the file in zend directory.

We put our class file in src/Application/SomeBundle/Zend/Cache/Backend/Custom.php
Our class namespace is Zend\Cache\Backend

So we want the class loader to load Zend\Cache\Backend* from Zend
directory, plus from our application directory.

```
$loader->registerNamespaces(array(
    'Zend'                       => __DIR__.'/vendor/zend/library',
    'Zend\\Cache\\Backend'       => __DIR__.'/Application/SomeBundle'
));
```

It does not matter the order of these two lines, it won't work. Because
the autoloader stops as soon as it finds an acceptable namespace, be the
file here or not.

This commit makes the loader try all acceptable namespaces until the file
is found.
Tests included.
