### PR TITLE
[FrameworkBundle] added getUser() and isAuthenticated() methods to SecurityHelper

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/SecurityHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/SecurityHelper.php
@@ -38,6 +38,16 @@ class SecurityHelper extends Helper
         return $this->context->vote($role, $object);
     }
 
+    public function getUser()
+    {
+        return $this->context->getUser();
+    }
+
+    public function isAuthenticated()
+    {
+        return $this->context->isAuthenticated();
+    }
+
     /**
      * Returns the canonical name of this helper.
      *


### PR DESCRIPTION
I added the missing `getUser()` and `isAuthenticated()` methods to the `SecurityHelper` templating helper.
