### PR TITLE
Csrf order fix

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -176,10 +176,11 @@ class Form extends FieldGroup
      */
     protected function generateCsrfToken($secret)
     {
-        if (!session_id()) {
+        $sessId = session_id();
+        if (!$sessId) {
             throw new \LogicException('The session must be started in order to generate a proper CSRF Token');
         }
-        return md5($secret.session_id().get_class($this));
+        return md5($secret.$sessId.get_class($this));
     }
 
     /**


### PR DESCRIPTION
I ran into a problem because I was fetching my user object (hence doing a session_start()) between the form declaration and the form binding, so the session_id() wasn't included in the form token, but was included in the form it tried to match against it, not fun :)
