### PR TITLE
Forms grouped validation fix

### DIFF
--- a/src/Symfony/Component/Form/Resources/config/validation.xml
+++ b/src/Symfony/Component/Form/Resources/config/validation.xml
@@ -17,7 +17,9 @@
 
   <class name="Symfony\Component\Form\Form">
     <getter property="data">
-      <constraint name="Valid" />
+      <constraint name="Valid">
+        <option name="groups">*</option>
+      </constraint>
     </getter>
     <getter property="postMaxSizeReached">
       <constraint name="AssertFalse">

--- a/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
@@ -87,7 +87,7 @@ abstract class ElementMetadata
     }
 
     /**
-     * Returns the constraints of the given group.
+     * Returns the constraints of the given group and global ones (* group).
      *
      * @param string $group The group name
      *
@@ -95,8 +95,14 @@ abstract class ElementMetadata
      */
     public function findConstraints($group)
     {
-        return isset($this->constraintsByGroup[$group])
+        $globalConstraints  = isset($this->constraintsByGroup['*'])
+                ? $this->constraintsByGroup['*']
+                : array();
+
+        $groupConstraints   = isset($this->constraintsByGroup[$group])
                 ? $this->constraintsByGroup[$group]
                 : array();
+
+        return array_merge((array) $globalConstraints, (array) $groupConstraints);
     }
 }


### PR DESCRIPTION
Before this fix, `validate($userForm, 'Registration')` doesn't  validate `$user` object at all, because `$user` with all it's constraints are stored inside form's `$data` variable, which group is _Default_.

Validator ignores **all** `$user` constraints, because `$data` constraints group is _Default_ & it's not equal to _Registration_ filter, passed to validator.

I've added `*` group support to `ElementMetadata::findConstraints(...)` getter. Constraints with such group will be returned in all `findConstraints()` call.
Last part - i've added this group to `Form::data` _Valid_ constraint options in `validation.xml`.
