### PR TITLE
Fix getHost 

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -441,7 +441,15 @@ class Request
 
             return trim($elements[count($elements) - 1]);
         } else {
-            return $this->headers->get('HOST', $this->server->get('SERVER_NAME', $this->server->get('SERVER_ADDR', '')));
+            $host = $this->headers->get('HOST');
+            if ( NULL === $host ) {
+                return $this->server->get('SERVER_NAME', $this->server->get('SERVER_ADDR', ''));
+            } else {
+                // Remove 'port number' from Host Header
+                $elements = explode(':', $host);
+
+                return trim($elements[0]);
+            }
         }
     }
 


### PR DESCRIPTION
- headers attribute is an HeaderBag instance whose get signature is
  get($key, $first = true)
  not the same as ParameterBag get signature (for server attribute)
  get($key, $default = null)
- remove port number from HOST header. To be consistent with backup values (SERVER_NAME, SERVER_ADDR).
  fix a problem with getUriForPath($path) where port number may be present twice.
