### PR TITLE
Collection transformer improvements

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Form/ValueTransformer/CollectionToStringTransformer.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Form/ValueTransformer/CollectionToStringTransformer.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\ValueTransformer\TransformationFailedException;
  * Transforms an instance of Doctrine\Common\Collections\Colletion into a string of unique names.
  *
  * Use-Cases for this transformer include: List of Tag-Names, List Of Group/User-Names or the like.
- * 
+ *
  * This transformer only makes sense if you know the list of related collections to be small and
  * that they have a unique identifier field that is of meaning to the user (Tag Names) and is
  * enforced to be unique in the storage.
@@ -73,7 +73,7 @@ class CollectionToStringTransformer extends BaseValueTransformer
                         ->getReflectionProperty($this->getOption('fieldName'));
 
         // 1. removing elements that are not yet present anymore
-        foreach ($collection AS $object) {
+        foreach ($collection as $object) {
             $uniqueIdent = $reflField->getValue($object);
             $key = \array_search($uniqueIdent, $values);
             if ($key === false) {
@@ -90,7 +90,7 @@ class CollectionToStringTransformer extends BaseValueTransformer
             $query = $em->createQuery();
             $needles = array();
             $i = 0;
-            foreach ($values AS $val) {
+            foreach ($values as $val) {
                 $query->setParameter(++$i, $val);
                 $needles[] = "?" . $i;
             }
@@ -98,7 +98,7 @@ class CollectionToStringTransformer extends BaseValueTransformer
             $query->setDql($dql);
             $newElements = $query->getResult();
 
-            foreach ($newElements AS $object) {
+            foreach ($newElements as $object) {
                 $collection->add($object);
 
                 $uniqueIdent = $reflField->getValue($object);
@@ -115,7 +115,7 @@ class CollectionToStringTransformer extends BaseValueTransformer
                     "element was detected and it is unknown how to create an instance of this element.");
             }
 
-            foreach ($values AS $newValue) {
+            foreach ($values as $newValue) {
                 $newInstance = \call_user_func($callback, $newValue);
                 if (!($newInstance instanceof $className)) {
                     throw new TransformationFailedException("Error while trying to create a new instance for ".
@@ -142,7 +142,7 @@ class CollectionToStringTransformer extends BaseValueTransformer
         $reflField = $em->getClassMetadata($this->getOption('className'))
                         ->getReflectionProperty($this->getOption('fieldName'));
 
-        foreach ($value AS $object) {
+        foreach ($value as $object) {
             $values[] = $reflField->getValue($object);
         }
         $callback = $this->getOption('implodeCallback');


### PR DESCRIPTION
Added a couple callbacks options to change default implode/explode behaviors of the Doctrine CollectionToStringTransformer class. Useful when you need smarter parsing than just exploding on a comma.
