### PR TITLE
Cookie Path Fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -224,9 +224,7 @@ class HeaderBag
             $cookie .= '; domain='.$domain;
         }
 
-        if ('/' !== $path) {
-            $cookie .= '; path='.$path;
-        }
+        $cookie .= '; path='.$path;
 
         if ($secure) {
             $cookie .= '; secure';


### PR DESCRIPTION
This fixes a bug where the path "/" was not properly set when the accessed page itself was not directly in the root folder "/". 

Steps to reproduce:
- access a page "/cookie/test/whatever"
- set a cookie for path "/"

The cookie will be set for path "/cookie/test/".
