### PR TITLE
Set cookie even when redirecting and profiler enabled

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
@@ -58,7 +58,10 @@ class WebDebugToolbarListener
                 $response->headers->get('location'), $response->headers->get('location'))
             );
             $r->headers->set('X-Debug-Token', $response->headers->get('X-Debug-Token'));
-
+            
+            if ($response->headers->has('Set-Cookie')) {
+                $r->headers->set('Set-Cookie', $response->headers->get('set-cookie'));
+            }
             $response = $r;
         }
 


### PR DESCRIPTION
This should be considered for other headers as well.
