### PR TITLE
Request->hasSession() fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -255,7 +255,9 @@ class Request
 
     public function hasSession()
     {
-        return $this->cookies->has(session_name());
+        $sessionName = null === $this->session ? 'SYMFONY_SESSION' : session_name();
+
+        return $this->cookies->has($sessionName);
     }
 
     public function setSession(Session $session)


### PR DESCRIPTION
This affects you if you do not have setup a session configuration yourself (thus no session implementation gets injected into the request), but you do call Request->getSession() from somewhere (e.g. your controller). Then a session with default values will be created.

Upon next request a call to ->hasSession() will return false if it is made before you again access the session from somewhere. This is incorrect since the session actually exists. Stateless requests are still possible and not affected by this.

While this commit fixes the problem, I think it would be cleaner if the decision - whether a session exists or not - was delegated to the concrete session / storage implementation. However, then we would always need an instance of the session which requires some more changes to the existing code to still support stateless requests.
