### PR TITLE
Fix twig form extension

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
@@ -154,6 +154,10 @@ class FormExtension extends \Twig_Extension
 
     public function renderWidget(FieldInterface $field, array $attributes = array(), $resources = null)
     {
+        if (null === $this->templates) {
+            $this->templates = $this->resolveResources($this->resources);
+        }
+
         if (null === $resources) {
             $parent = $field;
             $resources = array();


### PR DESCRIPTION
Fixes a warning when using `render_widget`

```
Warning: array_merge() [<a href='function.array-merge'>function.array-merge</a>]: Argument #1 is not an array in ***/symfony/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php line 202
```
