### PR TITLE
Exception handling fix for custom formats

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
@@ -46,8 +46,15 @@ class ExceptionController extends ContainerAware
             $exception->setStatusCode($exception->getCode());
         }
 
-        $response = $this->container->get('templating')->renderResponse(
-            'FrameworkBundle:Exception:'.($this->container->get('kernel')->isDebug() ? 'exception.php' : 'error.php'),
+        $templating = $this->container->get('templating');
+        $template = 'FrameworkBundle:Exception:'.($this->container->get('kernel')->isDebug() ? 'exception.php' : 'error.php');
+
+        if (!$templating->exists($template)) {
+            $this->container->get('request')->setRequestFormat('html');
+        }
+
+        $response = $templating->renderResponse(
+            $template,
             array(
                 'exception'      => $exception,
                 'logger'         => $logger,


### PR DESCRIPTION
I had the problem that, in a request that generates an ICS file, with the ICS format set, the exception page was trying to access exception.ics.php which fails and then you can't even see your original exception anymore.

This forces the fall back to html if the template for the current format is not available.
