### PR TITLE
[TwigBundle] RouteNode Fix

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Node/RouteNode.php
+++ b/src/Symfony/Bundle/TwigBundle/Node/RouteNode.php
@@ -35,8 +35,15 @@ class RouteNode extends \Twig_Node
             ->write('echo $this->env->getExtension(\'templating\')->getContainer()->get(\'router\')->generate(')
             ->subcompile($this->getNode('route'))
             ->raw(', ')
-            ->subcompile($this->getNode('route_attributes'))
-            ->raw(', ')
+        ;
+
+        $attr = $this->getNode('route_attributes');
+        if ($attr) {
+            $compiler->subcompile($attr);
+        } else {
+            $compiler->raw('array()');
+        }
+        $compiler->raw(', ')
             ->raw($this->getAttribute('absolute') ? 'true' : 'false')
             ->raw(");")
         ;


### PR DESCRIPTION
new 'path' or 'url' tag raise an exception if used without 'route_attributes' :

$this->getNode('route_attributes') returns null, and $compiler->subcompile(null) raise an error .

This patch seems to fix the problem.
