### PR TITLE
[DependencyInjection] Unresolved extension name in XmlFileLoader::validateSchema

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -235,11 +235,12 @@ class XmlFileLoader extends FileLoader
         if ($element = $dom->documentElement->getAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'schemaLocation')) {
             $items = preg_split('/\s+/', $element);
             for ($i = 0, $nb = count($items); $i < $nb; $i += 2) {
-                if (!$this->container->hasExtension($items[$i])) {
+                $extension_name = basename($items[$i]);
+                if (!$this->container->hasExtension($extension_name)) {
                     continue;
                 }
 
-                if (($extension = $this->container->getExtension($items[$i])) && false !== $extension->getXsdValidationBasePath()) {
+                if (($extension = $this->container->getExtension($extension_name)) && false !== $extension->getXsdValidationBasePath()) {
                     $path = str_replace($extension->getNamespace(), str_replace('\\', '/', $extension->getXsdValidationBasePath()).'/', $items[$i + 1]);
 
                     if (!file_exists($path)) {


### PR DESCRIPTION
i found unresolved extension name in XmlFileLoader::validateSchema.

XmlFileLoader.php(238)

<pre>
$this->container->hasExtension($item[$i]);
/**
 * echo $item[$I]
 * => http://www.symfony-project.org/schema/dic/symfony
 * $this->container->hasExtension() can't resolve namespace.
 * so i fixed $item[$i]  to basename($item[$i]);
 */
</pre>


this fix enable xml schema validation when loading xml configuration file.

I'm not sure about xml schema validation. Please fix that if you have a good idea.
