### PR TITLE
Validator annotation namespaces

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 
@@ -460,8 +461,17 @@ class FrameworkExtension extends Extension
                 $container->addResource(new FileResource($file));
             }
 
-            if (isset($config['validation']['annotations']) && $config['validation']['annotations'] === true) {
+            if (isset($config['validation']['annotations'])) {
+                if (isset($config['validation']['annotations']['namespaces']) && is_array($config['validation']['annotations']['namespaces'])) {
+                    $container->setParameter('validator.annotations.namespaces', array_merge(
+                        $container->getParameter('validator.annotations.namespaces'),
+                        $config['validation']['annotations']['namespaces']
+                    ));
+                }
+
                 $annotationLoader = new Definition($container->getParameter('validator.mapping.loader.annotation_loader.class'));
+                $annotationLoader->addArgument(new Parameter('validator.annotations.namespaces'));
+                
                 $container->setDefinition('validator.mapping.loader.annotation_loader', $annotationLoader);
 
                 $loader = $container->getDefinition('validator.mapping.loader.loader_chain');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -16,6 +16,9 @@
         <parameter key="validator.mapping.loader.yaml_files_loader.class">Symfony\Component\Validator\Mapping\Loader\YamlFilesLoader</parameter>
         <parameter key="validator.mapping.loader.static_method_loader.method_name">loadValidatorMetadata</parameter>
         <parameter key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory</parameter>
+        <parameter key="validator.annotations.namespaces" type="collection">
+            <parameter key="validation">Symfony\Component\Validator\Constraints\</parameter>
+        </parameter>
     </parameters>
 
     <services>

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -21,11 +21,17 @@ class AnnotationLoader implements LoaderInterface
 {
     protected $reader;
 
-    public function __construct()
+    public function __construct(array $paths = null)
     {
+        if (!$paths) {
+            $paths = array('validation' => 'Symfony\Component\Validator\Constraints\\');
+        }
+
         $this->reader = new AnnotationReader();
         $this->reader->setAutoloadAnnotations(true);
-        $this->reader->setAnnotationNamespaceAlias('Symfony\Component\Validator\Constraints\\', 'validation');
+        foreach ($paths AS $prefix => $path) {
+            $this->reader->setAnnotationNamespaceAlias($path, $prefix);
+        }
     }
 
     /**


### PR DESCRIPTION
Currently the validation annotation namespace "validation" => Symfony\Component\Validator\Validator is hardcoded.

This patch enhances the AnnotationLoader for validations to have configurable paths and annotation prefixes. Modify Framework Bundle to use the default validation annotation namespace:

```
app.config:
    validation:
      enabled: true
      annotations:
        namespaces:
          kanbanvalidator: Application\KanbanBundle\Validator\
```

The default Symfony validation prefix is always merged into this namespace configuration array. In this case you use the annotations in the following way:

```
/**
 * @kanbanvalidator:DoctrineUniqueField(class="Application\KanbanBundle\Entity\User", field="username")
 * @validation:NotBlank
 * @validation:MinLength(3)
 * @orm:Column(type="string", unique=true)
 * @var string
 */
private $username;
```
