### PR TITLE
Doctrine memcache

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -423,11 +423,11 @@ class DoctrineExtension extends Extension
     {
         $type = is_array($cacheDriver) && isset($cacheDriver['type']) ? $cacheDriver['type'] : $cacheDriver;
         if ($type === 'memcache') {
-            $memcacheClass = isset($cacheDriver['class']) ? $cacheDriver['class'] : '%'.sprintf('doctrine.orm.cache.%s_class', $type).'%';
+            $memcacheClass = '%'.sprintf('doctrine.orm.cache.%s_class', $type).'%';
             $cacheDef = new Definition($memcacheClass);
-            $memcacheHost = isset($cacheDriver['host']) ? $cacheDriver['host'] : '%doctrine.orm.cache.memcache_host%';
-            $memcachePort = isset($cacheDriver['port']) ? $cacheDriver['port'] : '%doctrine.orm.cache.memcache_port%';
-            $memcacheInstanceClass = isset($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%doctrine.orm.cache.memcache_instance_class%';
+            $memcacheHost = '%doctrine.orm.cache.memcache_host%';
+            $memcachePort = '%doctrine.orm.cache.memcache_port%';
+            $memcacheInstanceClass = '%doctrine.orm.cache.memcache_instance_class%';
             $memcacheInstance = new Definition($memcacheInstanceClass);
             $memcacheInstance->addMethodCall('connect', array($memcacheHost, $memcachePort));
             $container->setDefinition(sprintf('doctrine.orm.%s_memcache_instance', $entityManager['name']), $memcacheInstance);


### PR DESCRIPTION
When setting doctrine cache to Memcache, the container look like this:

<pre>protected function getDoctrine_Orm_DefaultMemcacheInstanceService()
{
        if (isset($this->shared['doctrine.orm.default_memcache_instance'])) return $this->shared['doctrine.orm.default_memcache_instance'];

        $instance = new m();
        $this->shared['doctrine.orm.default_memcache_instance'] = $instance;
        $instance->connect('m', 'm');

        return $instance;
}
</pre>


In the <code>DoctrineBundle\DoctrineExtension::getEntityManagerCacheDefinition()</code> method, the cacheDriver parameter seems to be a string, the phpdoc say it too.
