### PR TITLE
Webprofiler removed safe decorator

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -43,7 +43,7 @@ class ProfilerController extends ContainerAware
         } else {
             return $this->container->get('templating')->renderResponse('WebProfilerBundle:Profiler:index.php', array(
                 'token'     => $token,
-                'profiler'  => new SafeDecorator($profiler),
+                'profiler'  => $profiler,
                 'collector' => $profiler->get('request'),
                 'template'  => $this->getTemplate($profiler, '_panel', 'request'),
                 'panel'     => 'request',
@@ -147,7 +147,7 @@ class ProfilerController extends ContainerAware
 
         return $this->container->get('templating')->renderResponse('WebProfilerBundle:Profiler:toolbar.php', array(
             'position'  => $position,
-            'profiler'  => new SafeDecorator($profiler),
+            'profiler'  => $profiler,
             'templates' => $this->getTemplates($profiler, '_bar'),
         ));
     }


### PR DESCRIPTION
I was getting errors like this:

<pre>Fatal error: 
Call to undefined method Symfony\Component\OutputEscaper\SafeDecorator::get() 
in /Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.php on line 27</pre>

