### PR TITLE
Container::set should set the service in the shared array as well

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -59,15 +59,16 @@ class PhpDumper extends Dumper
     {
         $code = "\n    protected \$sharedServiceIds = array(\n";
 
-        foreach ($this->container->getDefinitions() as $id => $definition) {
+        $definitions = $this->container->getDefinitions();
+        foreach ($definitions as $id => $definition) {
             if ($definition->isShared()) {
-                $code .= sprintf("        %s => true,\n", $this->dumpValue($id));
+                $code .= sprintf("        %s => %s,\n", $this->dumpValue($id), $this->dumpValue($id));
             }
         }
 
         foreach ($this->container->getAliases() as $alias => $id) {
-            if ($definition->isShared()) {
-                $code .= sprintf("        %s => true,\n", $this->dumpValue($id));
+            if ($definitions[$id]->isShared()) {
+                $code .= sprintf("        %s => %s,\n", $this->dumpValue($alias), $this->dumpValue($id));
             }
         }
 
@@ -89,7 +90,7 @@ class PhpDumper extends Dumper
         parent::set(\$id, \$service);
 
         if (isset(\$this->sharedServiceIds[\$id])) {
-            \$this->shared[\$id] = \$service;
+            \$this->shared[\$this->sharedServiceIds[\$id]] = \$service;
         }
     }
 EOF;


### PR DESCRIPTION
The changes of yesterday [1] broke the "controller as services" feature, because the Request is now set on the container, but that does not set it in the protected $shared array of services. Then the Controller receives a Request object that has no attributes set etc.

I modified the PhpDumper so that this is now happening. I hope it makes sense, at least it fixes it for me.

[1] https://github.com/fabpot/symfony/commit/a471f6575945ea44eac333cbb9ae87dd016004a3
