### PR TITLE
Valid validator traversable

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ValidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ValidValidator.php
@@ -29,12 +29,12 @@ class ValidValidator extends ConstraintValidator
         $propertyPath = $this->context->getPropertyPath();
         $factory = $this->context->getClassMetadataFactory();
 
-        if (is_array($value)) {
+        if (is_array($value) || $value instanceof \Traversable) {
             foreach ($value as $key => $element) {
                 $walker->walkConstraint($constraint, $element, $group, $propertyPath.'['.$key.']');
             }
         } else if (!is_object($value)) {
-            throw new UnexpectedTypeException($value, 'object or array');
+            throw new UnexpectedTypeException($value, 'object, array or traversable');
         } else if ($constraint->class && !$value instanceof $constraint->class) {
             $this->setMessage($constraint->message, array('{{ class }}' => $constraint->class));
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/ValidValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/ValidValidatorTest.php
@@ -78,6 +78,23 @@ class ValidValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->isValid($array, $constraint));
     }
 
+    public function testWalkTraversable()
+    {
+        $this->context->setGroup('MyGroup');
+        $this->context->setPropertyPath('foo');
+
+        $constraint = new Valid();
+        $entity = new Entity();
+        // can only test for one object due to PHPUnit's mocking limitations
+        $traversable = new \ArrayObject( array('key' => $entity));
+
+        $this->walker->expects($this->once())
+                                 ->method('walkConstraint')
+                                 ->with($this->equalTo($constraint), $this->equalTo($entity), 'MyGroup', 'foo[key]');
+
+        $this->assertTrue($this->validator->isValid($traversable, $constraint));
+    }
+
     public function testValidateClass_Succeeds()
     {
         $metadata = $this->createClassMetadata();


### PR DESCRIPTION
Allow traversable objects to be walked by the Valid Constraint. Very useful on PersistentCollections for example.
