### PR TITLE
[Form] Field fix

### DIFF
--- a/src/Symfony/Component/Form/Field.php
+++ b/src/Symfony/Component/Form/Field.php
@@ -78,8 +78,10 @@ abstract class Field extends Configurable implements FieldInterface
 
         parent::__construct($options);
 
-        $this->normalizedData = $this->normalize($this->data);
-        $this->transformedData = $this->transform($this->normalizedData);
+        if (null !== $this->data) {
+            $this->normalizedData = $this->normalize($this->data);
+            $this->transformedData = $this->transform($this->normalizedData);
+        }
         $this->required = $this->getOption('required');
 
         $this->setPropertyPath($this->getOption('property_path'));


### PR DESCRIPTION
This doesn't seem to be needed since afaik the data is always null in the constructor, but I think it might be good to leave it in just in case some field defaults to something, or has a value set in configure() or something. Calling the transformers twice was wasteful though.
