### PR TITLE
Request Listener forces Session to be loaded

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -64,7 +64,7 @@ class RequestListener
         }
 
         // inject the session object if none is present
-        if (null === $request->getSession()) {
+        if (null === $request->getSession() && $this->container->has('session')) {
             $request->setSession($this->container->get('session'));
         }
 


### PR DESCRIPTION
Having no session service (which is valid), will result in an `InvalidArgumentException`. This change fixes this behavior.
