### PR TITLE
Dependency Injection Container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -161,7 +161,7 @@ class Container implements ContainerInterface, \ArrayAccess
      */
     public function has($id)
     {
-        return isset($this->services[$id]) || method_exists($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service');
+        return isset($this->services[$id]) || method_exists($this, 'get'.self::camelize($id).'Service');
     }
 
     /**
@@ -189,7 +189,7 @@ class Container implements ContainerInterface, \ArrayAccess
             return $this->services[$id];
         }
 
-        if (method_exists($this, $method = 'get'.strtr($id, array('_' => '', '.' => '_')).'Service')) {
+        if (method_exists($this, $method = 'get'.self::camelize($id).'Service')) {
             return $this->$method();
         }
 


### PR DESCRIPTION
Services without real IDs (like some Swiftmailer services `_05470b73fbb733331d09ccaeea16de96_1` => `Swift_Transport_Esmtp_Auth_CramMd5Authenticator`) cannot be retrieved because `strtr` does not convert the ID to the proper method name. Using `camelize()` like the `Dumper` classes do will fix that.

Using `strtr` with `$container->get('_05470b73fbb733331d09ccaeea16de96_1')` results in:
    $this->get05470b73fbb733331d09ccaeea16de961Service()

which does not exist, the method is:
    $this->get_05470b73fbb733331d09ccaeea16de961Service()

I don't know if the `camelize()` function should remove the leading underscore, but that's another question ;-)
