### PR TITLE
Minor issue regarding the port variable type in Request::getHttpHost()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -377,9 +377,9 @@ class Request
 
         $scheme = $this->getScheme();
         $name   = $this->server->get('SERVER_NAME');
-        $port   = $this->server->get('SERVER_PORT');
+        $port   = $this->getPort();
 
-        if (($scheme === 'http' && $port === 80) || ($scheme === 'https' && $port === 443)) {
+        if (($scheme == 'http' && $port == 80) || ($scheme == 'https' && $port == 443)) {
             return $name;
         } else {
             return $name.':'.$port;


### PR DESCRIPTION
Hey Fabien-

Sorry, this is really tiny, but I think this will eventually mess someone up.

This change allows the port to be a string (e.g. 80) without confusing getHttpHost(). This is semantically wrong, but the string is actually the convention that my server (Apache) seems to be following. The end result is that this method may in some cases return something like localhost:80. Of course this all pre-supposes the absence of the HOST header, and I'm not sure where that would be true.

There are several other ways to remedy this:
- type hinting to an integer inside getPort()
  or
- type hinting $port to a string (it is used as a string afterall) in getHttpHost() and changing the port values (80, 443) in the if statement to be strings.

Thanks
