### PR TITLE
Adds the ability to configure additional web profiler templates

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -59,6 +59,11 @@ class WebProfilerExtension extends Extension
                 $container->setParameter('debug.toolbar.intercept_redirects', (Boolean) $config[$key]);
             }
         }
+
+        if (isset($config['templates']) && $container->hasParameter('data_collector.templates')) {
+            $templates = array_merge($container->getParameter('data_collector.templates'), $config['templates']);
+            $container->setParameter('data_collector.templates', $templates);
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/schema/webprofiler-1.0.xsd
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/schema/webprofiler-1.0.xsd
@@ -8,7 +8,14 @@
     <xsd:element name="config" type="config" />
 
     <xsd:complexType name="config">
+        <xsd:sequence>
+            <xsd:element name="templates" type="templates" minOccurs="0" maxOccurs="1" />
+        </xsd:sequence>
         <xsd:attribute name="toolbar" type="xsd:boolean" />
         <xsd:attribute name="intercept-redirects" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="templates">
+        <xsd:anyAttribute processContents="lax" />
     </xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
If you want to add custom debugging informations to the web profiler toolbar and/or the web profiler you currently have to add the template to the file src/Symfony/Bundle/WebProfilerBundle/Resources/config/web_profiler.xml.

This commit lets you add templates in the application configuration.
## Configuration Examples
### PHP

```
$container->loadFromExtension('webprofiler', 'config', array(
    'toolbar' => true,
    'intercept-redirects' => true,
    'templates' => array(
        'redis' => 'RedisBundle:Profiler:redis.php',
    ),
));
```
### YAML

```
webprofiler.config:
    toolbar: true
    intercept_redirects: true
    templates:
        redis: RedisBundle:Profiler:redis.php
```
### XML

```
<webprofiler:config toolbar="true" intercept-redirects="true">
    <webprofiler:templates
        redis="RedisBundle:Profiler:redis.php"
    />
</webprofiler:config>
```
