### PR TITLE
Use security token with dao user provider

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
@@ -148,6 +148,7 @@ class SecurityExtension extends Extension
             'security.authentication.listener.x509',
             'security.authentication.listener.basic',
             'security.authentication.listener.digest',
+            'security.context_listener',
             'security.access_listener',
             'security.exception_listener',
         );
@@ -198,7 +199,7 @@ class SecurityExtension extends Extension
 
         // Context serializer listener
         if (!isset($firewall['stateless']) || !$firewall['stateless']) {
-            $listeners[] = new Reference('security.context_listener');
+            $listeners[] = new Reference($this->createContextListener($container, $id, $defaultProvider));
         }
 
         // Logout listener
@@ -234,6 +235,17 @@ class SecurityExtension extends Extension
         $exceptionListener = new Reference($this->createExceptionListener($container, $id, $defaultEntryPoint));
 
         return array($matcher, $listeners, $exceptionListener);
+    }
+
+    protected function createContextListener($container, $id, $userProvider)
+    {
+        $listenerId = 'security.context_listener.'.$id;
+        $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.context_listener'));
+        $arguments = $listener->getArguments();
+        $arguments[1] = new Reference($userProvider);
+        $listener->setArguments($arguments);
+
+        return $listenerId;
     }
 
     protected function createAuthenticationListeners($container, $id, $firewall, $defaultProvider, $providerIds)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -145,10 +145,5 @@
             <argument type="service" id="security.firewall.map" />
         </service>
         <service id="security.firewall.map" class="%security.firewall.map.class%" />
-
-        <service id="security.context_listener" class="%security.context_listener.class%">
-            <argument type="service" id="security.context" />
-            <argument type="service" id="logger" on-invalid="null" />
-        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
@@ -5,6 +5,12 @@
     xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="security.context_listener" class="%security.context_listener.class%">
+            <argument type="service" id="security.context" />
+            <argument type="service" id="security.user.provider.in_memory" />
+            <argument type="service" id="logger" on-invalid="null" />
+        </service>
+
         <service id="security.authentication.listener.form" class="%security.authentication.listener.form.class%">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\HttpKernel\Security\Firewall;
 
 use Symfony\Component\Security\SecurityContext;
+use Symfony\Component\Security\User\UserProviderInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
@@ -27,11 +28,13 @@ use Symfony\Component\Security\Authentication\Token\AnonymousToken;
 class ContextListener
 {
     protected $context;
+    protected $userProvider;
     protected $logger;
 
-    public function __construct(SecurityContext $context, LoggerInterface $logger = null)
+    public function __construct(SecurityContext $context, UserProviderInterface $userProvider, LoggerInterface $logger = null)
     {
         $this->context = $context;
+        $this->userProvider = $userProvider;
         $this->logger = $logger;
     }
 
@@ -68,11 +71,9 @@ class ContextListener
 
             $token = unserialize($token);
 
-            $this->context->setToken($token);
+            $token->setUser($this->userProvider->loadUserByUsername($token->getUser()));
 
-            // FIXME: If the user is not an object, it probably means that it is persisted with a DAO
-            // we need to load it now (that does not happen right now as the Token serialize the user
-            // even if it is an object -- see Token)
+            $this->context->setToken($token);
         }
     }
 

--- a/src/Symfony/Component/Security/Authentication/Token/Token.php
+++ b/src/Symfony/Component/Security/Authentication/Token/Token.php
@@ -113,6 +113,14 @@ abstract class Token implements TokenInterface
     /**
      * {@inheritdoc}
      */
+    public function setUser($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function eraseCredentials()
     {
         if ($this->getCredentials() instanceof AccountInterface) {
@@ -145,9 +153,7 @@ abstract class Token implements TokenInterface
      */
     public function serialize()
     {
-        // FIXME: don't serialize the user object, just the username (see ContextListener)
-        //return serialize(array((string) $this, $this->credentials, $this->authenticated, $this->roles, $this->immutable));
-        return serialize(array($this->user, $this->credentials, $this->authenticated, $this->roles, $this->immutable));
+        return serialize(array((string) $this->user, $this->credentials, $this->authenticated, $this->roles, $this->immutable));
     }
 
     /**

--- a/src/Symfony/Component/Security/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Authentication/Token/TokenInterface.php
@@ -54,6 +54,13 @@ interface TokenInterface extends \Serializable
     function getUser();
 
     /**
+     * Sets the user instance
+     *
+     * @param object $user The User instance
+     */
+    function setUser($user);
+
+    /**
      * Checks if the user is authenticated or not.
      *
      * @return Boolean true if the token has been authenticated, false otherwise


### PR DESCRIPTION
I send this pull request again as Github lost it sunday.

It's about serializing only the username when persisting the token. And use the firewall user provider to fetch the user back from the username.
It makes the context_listener service not shared, and gives it a dependency to the user provider.

Johanness mentioned the fact that this is dangerous when using multiple firewalls. The same username can refer to different users depending on the user provider.

This code is not ready to be merged, but I hope it makes a starting point for discussions.
