### PR TITLE
Add missing "errors" parameter to twig form error block

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
@@ -173,6 +173,7 @@ class FormExtension extends \Twig_Extension
 
         return $this->templates['errors']->getBlock('errors', array(
             'field'  => $field,
+            'errors' => $field->getErrors(),
             'params' => $parameters,
         ));
     }


### PR DESCRIPTION
Because the twig block expects a "errors" parameter.
