### PR TITLE
Fixed "Symfony 2" to "Symfony2" in FrameworkBundle:Default:index.php

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Default/index.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Default/index.php
@@ -1,5 +1,5 @@
 <h1>Congratulations!</h1>
 
 <p>
-    You have successfully created a new Symfony 2 application.
+    You have successfully created a new Symfony2 application.
 </p>


### PR DESCRIPTION
Fixed "Symfony 2" to "Symfony2" in FrameworkBundle:Default:index.php
