### PR TITLE
Rename HeaderBag::validateCookieName to validateCookie

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -175,7 +175,7 @@ class HeaderBag
      */
     public function setCookie($name, $value, $domain = null, $expires = null, $path = '/', $secure = false, $httponly = true)
     {
-        $this->validateCookieName($name, $value);
+        $this->validateCookie($name, $value);
 
         return $this->set('Cookie', sprintf('%s=%s', $name, urlencode($value)));
     }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -63,7 +63,7 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function setCookie($name, $value, $domain = null, $expires = null, $path = '/', $secure = false, $httponly = true)
     {
-        $this->validateCookieName($name, $value);
+        $this->validateCookie($name, $value);
 
         $cookie = sprintf('%s=%s', $name, urlencode($value));
 


### PR DESCRIPTION
The method name has changed, but in two places the code is not updated to reflect this change.
