### PR TITLE
Session auto start

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -313,6 +313,10 @@ class FrameworkExtension extends Extension
             }
         }
 
+        if (isset($config['auto_start']) || isset($config['auto-start'])) {
+            $container->getDefinition('session')->addMethodCall('start');
+        }
+
         if (isset($config['class'])) {
             $container->setParameter('session.class', $config['class']);
         }


### PR DESCRIPTION
If a session have not been started when rendering a form it will throw an exception. Also most of the time you would want to have a session started eg. when using the Security component where tokens are serialized into the session.
