### PR TITLE
Flash api fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -226,6 +226,16 @@ class Session implements \Serializable
         return array_key_exists($name, $this->attributes['_flash']);
     }
 
+    public function removeFlash($name)
+    {
+        unset($this->attributes['_flash'][$name]);
+    }
+
+    public function clearFlashes()
+    {
+        $this->attributes['_flash'] = array();
+    }
+
     public function save()
     {
         if (true === $this->started) {


### PR DESCRIPTION
Fixed naming for consistency with the rest and added remove possibility for json responses for example that could want to clear the flash messages since they suppress the redirect.
