### PR TITLE
Standard action name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -64,7 +64,7 @@ class ControllerResolver extends BaseControllerResolver
                 // controller in the service:method notation
                 list($service, $method) = explode(':', $controller);
 
-                return array($this->container->get($service), $method);
+                return array($this->container->get($service), $method.'Action');
             } else {
                 throw new \LogicException(sprintf('Unable to parse the controller name "%s".', $controller));
             }


### PR DESCRIPTION
At the moment when using controllers as services you have to specify "fooService:fooAction" in the route _controller param, this is sub-optimal and doesn't enforce the convention
