### PR TITLE
Removed @rule in exception controller

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
@@ -36,8 +36,8 @@ class ExceptionController extends ContainerAware
         $this->container->get('request')->setRequestFormat($format);
 
         $currentContent = '';
-        while (false !== $content = @ob_get_clean()) {
-            $currentContent .= $content;
+        while (ob_get_level()) {
+            $currentContent .= ob_get_clean();
         }
 
         if ('Symfony\Component\Security\Exception\AccessDeniedException' === $exception->getClass()) {


### PR DESCRIPTION
I'm not sure why it was added in https://github.com/fabpot/symfony/commit/7b835cbc572ccf241259d77f702e1dd0cf22715a - but I'm pretty sure this fixes it, even in php 5.4, otherwise I'd say there is a bug in php 5.4
