### PR TITLE
Strict var fixes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.twig
@@ -28,7 +28,7 @@
         {% include 'FrameworkBundle:Exception:traces.twig' with ['exception': e, 'position': position, 'count': previous_count] only %}
     {% endfor %}
 
-    {% if null != logger %}
+    {% if logger %}
         <div class="block">
             <h3>
                 {% if logger.counterrors %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/logs.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/logs.twig
@@ -1,7 +1,7 @@
 <ol>
     {% for log in logs %}
-        <li{% if 'ERR' == log.priorityname %} class="error"{% endif %}>
-            {{ log.priorityname }}
+        <li{% if 'ERR' == log.priorityName %} class="error"{% endif %}>
+            {{ log.priorityName }}
             {{ log.message }}
         </li>
     {% endfor %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/trace.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/trace.twig
@@ -1,7 +1,7 @@
 {% if trace.function %}
     at <strong><abbr title="{{ trace.class }}">{{ trace.short_class }}</abbr>{{ trace.type ~ trace.function }}</strong>({{ trace.args|format_args }})<br />
 {% endif %}
-{% if trace.file and trace.line %}
+{% if trace.file is defined and trace.line is defined %}
     in <em>{{ trace.file|format_file(trace.line) }}</em>
     <a href="#" onclick="toggle('trace_{{ prefix ~ '_' ~ i }}'); return false;">&raquo;</a><br />
     <div id="trace_{{ prefix ~ '_' ~ i }}" class="trace" style="display: {{ 0 == i ? 'block' : 'none' }}">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/trace.txt.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/trace.txt.twig
@@ -3,6 +3,6 @@
 {% else %}
                 at n/a
 {% endif %}
-{% if trace.file and trace.line %}
+{% if trace.file is defined and trace.line is defined %}
                     in {{ trace.file }} line {{ trace.line }}
 {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.twig
@@ -17,8 +17,8 @@ Logs
     {% if collector.logs %}
         <ul class="alt">
             {% for i, log in collector.logs %}
-                <li class="{{ i is odd ? 'odd' : 'even' }}{% if 'ERR' == log.priorityname %} error{% endif %}">
-                    {{ log.priorityname }}
+                <li class="{{ i is odd ? 'odd' : 'even' }}{% if 'ERR' == log.priorityName %} error{% endif %}">
+                    {{ log.priorityName }}
                     {{ log.message }}
                 </li>
             {% endfor %}


### PR DESCRIPTION
Some templates in the profiler & the exception handling exploded when twig's strict_variables is enabled
