### PR TITLE
Console\Application::addCommand() ->  Console\Application::add() rename

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -152,7 +152,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
         foreach ($finder as $file) {
             $r = new \ReflectionClass($prefix.strtr($file->getPath(), array($dir => '', '/' => '\\')).'\\'.basename($file, '.php'));
             if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract()) {
-                $application->addCommand($r->newInstance());
+                $application->add($r->newInstance());
             }
         }
     }

--- a/src/Symfony/Component/HttpKernel/bootstrap.php
+++ b/src/Symfony/Component/HttpKernel/bootstrap.php
@@ -47,7 +47,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface {
         foreach ($finder as $file) {
             $r = new \ReflectionClass($prefix.strtr($file->getPath(), array($dir => '', '/' => '\\')).'\\'.basename($file, '.php'));
             if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract()) {
-                $application->addCommand($r->newInstance()); } } }
+                $application->add($r->newInstance()); } } }
     protected function initReflection() {
         $tmp = dirname(str_replace('\\', '/', get_class($this)));
         $this->namespacePrefix = str_replace('/', '\\', dirname($tmp));


### PR DESCRIPTION
Hey Fabien-

This is left over from the method name refactoring - I found no other instances of "addCommand".

Thanks!
