### PR TITLE
Enforcement of required "options" on Command component

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -236,9 +236,9 @@ class Command
      *
      * @param string  $name        The option name
      * @param string  $shortcut    The shortcut (can be null)
-     * @param integer $mode        The option mode: self::PARAMETER_REQUIRED, self::PARAMETER_NONE or self::PARAMETER_OPTIONAL
+     * @param integer $mode        The option mode: see the InputOption::PARAMETER_* constants
      * @param string  $description A description text
-     * @param mixed   $default     The default value (must be null for self::PARAMETER_REQUIRED or self::PARAMETER_NONE)
+     * @param mixed   $default     The default value (must be null for InputOption::PARAMETER_REQUIRED or InputOption::PARAMETER_NONE)
      *
      * @return Command The current instance
      */

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -71,6 +71,12 @@ abstract class Input implements InputInterface
         if (count($this->arguments) < $this->definition->getArgumentRequiredCount()) {
             throw new \RuntimeException('Not enough arguments.');
         }
+
+        foreach ($this->definition->getOptions() as $name => $option) {
+            if ($this->getOption($name) === null && $option->isParameterRequired()) {
+                throw new \RuntimeException(sprintf('Missing value for required option "%s".', $name));
+            }
+        }
     }
 
     public function isInteractive()

--- a/tests/Symfony/Tests/Component/Console/Input/InputTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputTest.php
@@ -85,14 +85,14 @@ class InputTest extends \PHPUnit_Framework_TestCase
 
     public function testValidate()
     {
+        // Test required arguments
         $input = new ArrayInput(array());
         $input->bind(new InputDefinition(array(new InputArgument('name', InputArgument::REQUIRED))));
 
         try {
             $input->validate();
             $this->fail('->validate() throws a \RuntimeException if not enough arguments are given');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e, '->validate() throws a \RuntimeException if not enough arguments are given');
+        } catch (\RuntimeException $e) {
             $this->assertEquals('Not enough arguments.', $e->getMessage());
         }
 
@@ -103,6 +103,24 @@ class InputTest extends \PHPUnit_Framework_TestCase
             $input->validate();
         } catch (\RuntimeException $e) {
             $this->fail('->validate() does not throw a \RuntimeException if enough arguments are given');
+        }
+
+        // Test required options
+        $input = new ArrayInput(array());
+        $input->bind(new InputDefinition(array(new InputOption('name', null, InputOption::PARAMETER_REQUIRED))));
+
+        try {
+            $input->validate();
+            $this->fail('->validate() throws a \RuntimeException if a required option is not provided');
+        } catch (\RuntimeException $e) {
+            $this->assertEquals('Missing value for required option "name".', $e->getMessage());
+        }
+
+        $input->setOption('name', 'foo');
+        try {
+            $input->validate();
+        } catch (\RuntimeException $e) {
+            $this->fail('->validate() throws a \RuntimeException if a required option is not provided');
         }
     }
 


### PR DESCRIPTION
Hey Fabien-

Prior to this change, InputOption objects could be given a PARAMETER_REQUIRED mode, but there was no enforcement of that "required" mode. This fixes that.

Also, it's strange to have "required options" as that's what arguments are for. I can't think of an example where a unix command _requires_ a --foo=bar styled option.

In other words, I can't think of a reason to keep the PARAMETER_REQUIRED behavior, but let me know what you think.

Thanks!
