### PR TITLE
Closes Ticket 9297

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -30,7 +30,7 @@ class UrlValidator extends ConstraintValidator
 
     public function isValid($value, Constraint $constraint)
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return true;
         }
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/UrlValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/UrlValidatorTest.php
@@ -18,6 +18,11 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->validator->isValid(null, new Url()));
     }
+	
+	public function testEmptyStringIsValid()
+    {
+        $this->assertTrue($this->validator->isValid('', new Url()));
+    }
 
     public function testExpectsStringCompatibleType()
     {


### PR DESCRIPTION
Fix UrlValidator. Now it accepts an empty string as a valid value, so you can make a form field with this constraint optional.
