### PR TITLE
expand security helper to support getUser()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/SecurityHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/SecurityHelper.php
@@ -42,6 +42,15 @@ class SecurityHelper extends Helper
         return $this->context->vote($role, $object);
     }
 
+    public function getUser()
+    {
+        if (null === $this->context) {
+            return false;
+        }
+
+        return $this->context->getUser();
+    }
+
     /**
      * Returns the canonical name of this helper.
      *


### PR DESCRIPTION
Frequently one will need to access the some information about the user inside the layout and its not really practical to have to push this into the template from the controller:
{% set user = _view.security.getUser() %}
