### PR TITLE
Fix doctrine command

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -139,7 +139,8 @@ abstract class DoctrineCommand extends Command
         $bundleMetadatas = array();
         $entityManagers = $this->getDoctrineEntityManagers();
         foreach ($entityManagers as $key => $em) {
-            $cmf = new SymfonyDisconnectedClassMetadataFactory($em);
+            $cmf = new SymfonyDisconnectedClassMetadataFactory();
+            $cmf->setEntityManager($em);
             $metadatas = $cmf->getAllMetadata();
             foreach ($metadatas as $metadata) {
 


### PR DESCRIPTION
This fix the creation of the MetadataFactory as the EntityManager is not passed to the constructor any more but has to be set after.
