### PR TITLE
Yaml parser should always return array

### DIFF
--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -92,7 +92,7 @@ class Yaml
             throw new \InvalidArgumentException(sprintf('Unable to parse %s: %s', $file ? sprintf('file "%s"', $file) : 'string', $e->getMessage()), 0, $e);
         }
 
-        return $ret;
+        return (array) $ret;
     }
 
     /**


### PR DESCRIPTION
If you parse an empty file you get null, and then stuff like the Routing YamlFileLoader try to foreach over null and blow up
