### PR TITLE
[Form] PropertyPath: fixed __get __set

### DIFF
--- a/src/Symfony/Component/Form/PropertyPath.php
+++ b/src/Symfony/Component/Form/PropertyPath.php
@@ -318,13 +318,16 @@ class PropertyPath implements \IteratorAggregate
                 }
 
                 return $object->$isser();
+            } else if ($reflClass->hasMethod('__get')) {
+	            // needed to support magic method __get
+	            return $object->$property;
             } else if ($reflClass->hasProperty($property)) {
                 if (!$reflClass->getProperty($property)->isPublic()) {
                     throw new PropertyAccessDeniedException(sprintf('Property "%s" is not public in class "%s". Maybe you should create the method "get%s()" or "is%s()"?', $property, $reflClass->getName(), ucfirst($property), ucfirst($property)));
                 }
 
                 return $object->$property;
-            } else if (property_exists($object, $property) || $reflClass->hasMethod('__get')) {
+            } else if (property_exists($object, $property)) {
                 // needed to support \stdClass instances
                 return $object->$property;
             } else {
@@ -361,13 +364,16 @@ class PropertyPath implements \IteratorAggregate
                 }
 
                 $objectOrArray->$setter($value);
+            } else if ($reflClass->hasMethod('__set')) {
+                // needed to support magic method __set
+                $objectOrArray->$property = $value;
             } else if ($reflClass->hasProperty($property)) {
                 if (!$reflClass->getProperty($property)->isPublic()) {
                     throw new PropertyAccessDeniedException(sprintf('Property "%s" is not public in class "%s". Maybe you should create the method "set%s()"?', $property, $reflClass->getName(), ucfirst($property)));
                 }
 
                 $objectOrArray->$property = $value;
-            } else if (property_exists($objectOrArray, $property) || $reflClass->hasMethod('__get')) {
+            } else if (property_exists($objectOrArray, $property)) {
                 // needed to support \stdClass instances
                 $objectOrArray->$property = $value;
             } else {

--- a/tests/Symfony/Tests/Component/Form/Fixtures/Magician.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/Magician.php
@@ -4,15 +4,15 @@ namespace Symfony\Tests\Component\Form\Fixtures;
 
 class Magician
 {
-    private $properties = array();
+    private $foobar;
 
-    public function __set($name, $value)
+    public function __set($property, $value)
     {
-        $this->properties[$name] = $value;
+        $this->$property = $value;
     }
 
-    public function __get($name)
+    public function __get($property)
     {
-        return isset($this->properties[$name]) ? $this->properties[$name] : null;
+        return isset($this->$property) ? $this->$property : null;
     }
 }


### PR DESCRIPTION
I did the commit to implement magic get, set but i have forgotten something:

When we have a class like this:

<pre>
class Foo
{
  protected $foobar;

  function __get($p) 
  {
    return $this->$p;
  }

  function __set($p, $v) 
  {
    $this->$p = $v;
  }
}
</pre>


Now if we call:

<pre>
$foo = new Foo;
$foo->foobar = 'value';
</pre>


It throw an exception <em>Property "foobar" is not public in class "Foo".</em>

So the check for magic methods get and set should be <b>BEFORE</b> <code>$reflClass->hasProperty()</code>
