### PR TITLE
Command assets symlink

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -53,7 +53,7 @@ class AssetsInstallCommand extends Command
         $filesystem = new Filesystem();
 
         // Create the bundles directory otherwise symlink will fail.
-        mkdir($input->getArgument('target').'/bundles/', 0777, true);
+        $filesystem->mkdirs($input->getArgument('target').'/bundles/', 0777);
 
         foreach ($this->container->get('kernel')->getBundles() as $bundle) {
             if (is_dir($originDir = $bundle->getPath().'/Resources/public')) {
@@ -66,7 +66,7 @@ class AssetsInstallCommand extends Command
                 if ($input->getOption('symlink')) {
                     $filesystem->symlink($originDir, $targetDir);
                 } else {
-                    mkdir($targetDir, 0777, true);
+                    $filesystem->mkdirs($targetDir, 0777);
                     $filesystem->mirror($originDir, $targetDir);
                 }
             }


### PR DESCRIPTION
Fixes an error that is thrown if the bundles directory in the targetDir did not exists 
