### PR TITLE
[Security] Token unserialize event

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -148,6 +148,7 @@
 
         <service id="security.context_listener" class="%security.context_listener.class%">
             <argument type="service" id="security.context" />
+            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
     </services>

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
@@ -28,10 +28,12 @@ class ContextListener
 {
     protected $context;
     protected $logger;
+    protected $dispatcher;
 
-    public function __construct(SecurityContext $context, LoggerInterface $logger = null)
+    public function __construct(SecurityContext $context, EventDispatcher $dispatcher, LoggerInterface $logger = null)
     {
         $this->context = $context;
+        $this->dispatcher = $dispatcher;
         $this->logger = $logger;
     }
 
@@ -68,11 +70,10 @@ class ContextListener
 
             $token = unserialize($token);
 
-            $this->context->setToken($token);
+            $event = new Event($token, 'security.token.unserialize', array());
+            $this->dispatcher->notify($event);
 
-            // FIXME: If the user is not an object, it probably means that it is persisted with a DAO
-            // we need to load it now (that does not happen right now as the Token serialize the user
-            // even if it is an object -- see Token)
+            $this->context->setToken($token);
         }
     }
 


### PR DESCRIPTION
Another approach to fix https://github.com/fabpot/symfony/pull/173

Here, the user is still serialized. But we send an event right after unserializing it, to give the application a chance to perform actions on it. Such as merge it to an object manager.
