### PR TITLE
Route names should allow dots

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -42,7 +42,7 @@ class RouteCollection
      */
     public function add($name, Route $route)
     {
-        if (!preg_match('/^[a-z0-9A-Z_]+$/', $name)) {
+        if (!preg_match('/^[a-z0-9A-Z_.]+$/', $name)) {
             throw new \InvalidArgumentException(sprintf('Name "%s" contains non valid characters for a route name.', $name));
         }
 


### PR DESCRIPTION
I'm not sure if there is a good reason not to allow dots, but since service names and config keys typically have dots in them, I think it should be possible for routes as well.
