### PR TITLE
Making the doctrine proxy dir configurable

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -215,6 +215,7 @@ class DoctrineExtension extends Extension
             'query_cache_driver',
             'result_cache_driver',
             'proxy_namespace',
+            'proxy_dir',
             'auto_generate_proxy_classes'
         );
         foreach ($options as $key) {
@@ -250,7 +251,6 @@ class DoctrineExtension extends Extension
     protected function loadOrmEntityManager(array $entityManager, ContainerBuilder $container)
     {
         $defaultEntityManager = $container->getParameter('doctrine.orm.default_entity_manager');
-        $proxyCacheDir = $container->getParameter('kernel.cache_dir').'/doctrine/orm/Proxies';
 
         $ormConfigDef = new Definition('Doctrine\ORM\Configuration');
         $container->setDefinition(sprintf('doctrine.orm.%s_configuration', $entityManager['name']), $ormConfigDef);
@@ -263,7 +263,7 @@ class DoctrineExtension extends Extension
             'setQueryCacheImpl' => new Reference(sprintf('doctrine.orm.%s_query_cache', $entityManager['name'])),
             'setResultCacheImpl' => new Reference(sprintf('doctrine.orm.%s_result_cache', $entityManager['name'])),
             'setMetadataDriverImpl' => new Reference('doctrine.orm.metadata_driver'),
-            'setProxyDir' => $proxyCacheDir,
+            'setProxyDir' => $container->getParameter('doctrine.orm.proxy_dir'),
             'setProxyNamespace' => $container->getParameter('doctrine.orm.proxy_namespace'),
             'setAutoGenerateProxyClasses' => $container->getParameter('doctrine.orm.auto_generate_proxy_classes')
         );

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -14,6 +14,7 @@
 
         <!-- proxies -->
         <parameter key="doctrine.orm.proxy_namespace">Proxies</parameter>
+        <parameter key="doctrine.orm.proxy_dir">%kernel.cache_dir%/doctrine/orm/Proxies</parameter>
         <parameter key="doctrine.orm.auto_generate_proxy_classes">false</parameter>
 
         <!-- cache -->


### PR DESCRIPTION
The proxy dir being in the cache dir isn't convenient for everyone. My deploy script for example ignores the cache dir, so I'd like to be able to generate the proxies in some other directory that will be part of the deployed code. 

Also the doctrine:generate:proxies command already has a target dir option so if it's not configurable it kind of becomes useless.
