### PR TITLE
Draft for more flexible password encoding

### DIFF
--- a/src/Symfony/Component/Security/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Authentication/Provider/DaoAuthenticationProvider.php
@@ -59,7 +59,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
             throw new BadCredentialsException('Bad credentials');
         }
 
-        if (!$this->passwordEncoder->isPasswordValid($account->getPassword(), $presentedPassword, $account->getSalt())) {
+        if (!$this->passwordEncoder->isPasswordValid($presentedPassword, $account)) {
             throw new BadCredentialsException('Bad credentials');
         }
     }

--- a/src/Symfony/Component/Security/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Encoder/MessageDigestPasswordEncoder.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\Security\Encoder;
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  */
+use Symfony\Component\Security\User\AccountInterface;
+
 class MessageDigestPasswordEncoder extends BasePasswordEncoder
 {
     protected $algorithm;
@@ -38,13 +40,13 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
     /**
      * {@inheritdoc}
      */
-    public function encodePassword($raw, $salt)
+    public function encodePassword($raw, AccountInterface $account)
     {
         if (!in_array($this->algorithm, hash_algos(), true)) {
             throw new \LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
         }
 
-        $salted = $this->mergePasswordAndSalt($raw, $salt);
+        $salted = $this->mergePasswordAndSalt($raw, $account->getSalt());
         $digest = hash($this->algorithm, $salted, true);
 
         // "stretch" hash
@@ -58,8 +60,8 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
     /**
      * {@inheritdoc}
      */
-    public function isPasswordValid($encoded, $raw, $salt)
+    public function isPasswordValid($raw, AccountInterface $account)
     {
-        return $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
+        return $this->comparePasswords($account->getPassword(), $this->encodePassword($raw, $account));
     }
 }

--- a/src/Symfony/Component/Security/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Encoder/PasswordEncoderInterface.php
@@ -11,6 +11,8 @@ namespace Symfony\Component\Security\Encoder;
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Security\User\AccountInterface;
+
 /**
  * PasswordEncoderInterface is the interface for all encoders.
  *
@@ -22,20 +24,19 @@ interface PasswordEncoderInterface
      * Encodes the raw password.
      *
      * @param string $raw  The password to encode
-     * @param string $salt The salt
+     * @param AccountInterface $account The salt
      *
      * @return string The encoded password
      */
-    function encodePassword($raw, $salt);
+    function encodePassword($raw, AccountInterface $account);
 
     /**
      * Checks a raw password against an encoded password.
      *
-     * @param string $encoded An encoded password
      * @param string $raw     A raw password
-     * @param string $salt    The salt
+     * @param AccountInterface $account
      *
      * @return Boolean true if the password is valid, false otherwise
      */
-    function isPasswordValid($encoded, $raw, $salt);
+    function isPasswordValid($raw, AccountInterface $account);
 }

--- a/src/Symfony/Component/Security/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Encoder/PlaintextPasswordEncoder.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\Security\Encoder;
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  */
+use Symfony\Component\Security\User\AccountInterface;
+
 class PlaintextPasswordEncoder extends BasePasswordEncoder
 {
     protected $ignorePasswordCase;
@@ -28,22 +30,22 @@ class PlaintextPasswordEncoder extends BasePasswordEncoder
     /**
      * {@inheritdoc}
      */
-    public function encodePassword($raw, $salt)
+    public function encodePassword($raw, AccountInterface $account)
     {
-        return $this->mergePasswordAndSalt($raw, $salt);
+        return $this->mergePasswordAndSalt($raw, $account->getSalt());
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isPasswordValid($encoded, $raw, $salt)
+    public function isPasswordValid($raw, AccountInterface $account)
     {
-        $pass2 = $this->mergePasswordAndSalt($raw, $salt);
+        $pass2 = $this->mergePasswordAndSalt($raw, $account->getSalt());
 
         if (!$this->ignorePasswordCase) {
-            return $this->comparePasswords($encoded, $pass2);
+            return $this->comparePasswords($account->getPassword(), $pass2);
         } else {
-            return $this->comparePasswords(strtolower($encoded), strtolower($pass2));
+            return $this->comparePasswords(strtolower($account->getPassword()), strtolower($pass2));
         }
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Encoder/BasePasswordEncoderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Encoder/BasePasswordEncoderTest.php
@@ -10,19 +10,6 @@
 
 namespace Symfony\Tests\Component\Security\Encoder;
 
-use Symfony\Component\Security\Encoder\BasePasswordEncoder;
-
-class PasswordEncoder extends BasePasswordEncoder
-{
-    public function encodePassword($raw, $salt)
-    {
-    }
-
-    public function isPasswordValid($encoded, $raw, $salt)
-    {
-    }
-}
-
 class BasePasswordEncoderTest extends \PHPUnit_Framework_TestCase
 {
     public function testComparePassword()
@@ -54,7 +41,7 @@ class BasePasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     protected function invokeDemergePasswordAndSalt($password)
     {
-        $encoder = new PasswordEncoder();
+        $encoder = $this->getEncoder();
         $r = new \ReflectionObject($encoder);
         $m = $r->getMethod('demergePasswordAndSalt');
         $m->setAccessible(true);
@@ -64,7 +51,7 @@ class BasePasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     protected function invokeMergePasswordAndSalt($password, $salt)
     {
-        $encoder = new PasswordEncoder();
+        $encoder = $this->getEncoder();
         $r = new \ReflectionObject($encoder);
         $m = $r->getMethod('mergePasswordAndSalt');
         $m->setAccessible(true);
@@ -74,11 +61,16 @@ class BasePasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     protected function invokeComparePasswords($p1, $p2)
     {
-        $encoder = new PasswordEncoder();
+        $encoder = $this->getEncoder();
         $r = new \ReflectionObject($encoder);
         $m = $r->getMethod('comparePasswords');
         $m->setAccessible(true);
 
         return $m->invoke($encoder, $p1, $p2);
+    }
+    
+    protected function getEncoder()
+    {
+    	return $this->getMockForAbstractClass('Symfony\Component\Security\Encoder\BasePasswordEncoder');
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Encoder/MessageDigestPasswordEncoderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Encoder/MessageDigestPasswordEncoderTest.php
@@ -17,20 +17,24 @@ class MessageDigestPasswordEncoderTest extends \PHPUnit_Framework_TestCase
     public function testIsPasswordValid()
     {
         $encoder = new MessageDigestPasswordEncoder();
+        $account = $this->getAccount(hash('sha256', 'password'), '');
 
-        $this->assertTrue($encoder->isPasswordValid(hash('sha256', 'password'), 'password', ''));
+        $this->assertTrue($encoder->isPasswordValid('password', $account));
     }
 
     public function testEncodePassword()
     {
         $encoder = new MessageDigestPasswordEncoder();
-        $this->assertSame(hash('sha256', 'password'), $encoder->encodePassword('password', ''));
+        $account = $this->getAccount(null, '');
+        $this->assertSame(hash('sha256', 'password'), $encoder->encodePassword('password', $account));
 
         $encoder = new MessageDigestPasswordEncoder('sha256', true);
-        $this->assertSame(base64_encode(hash('sha256', 'password', true)), $encoder->encodePassword('password', ''));
+        $account = $this->getAccount(null, '');
+        $this->assertSame(base64_encode(hash('sha256', 'password', true)), $encoder->encodePassword('password', $account));
 
         $encoder = new MessageDigestPasswordEncoder('sha256', false, 2);
-        $this->assertSame(hash('sha256', hash('sha256', 'password', true)), $encoder->encodePassword('password', ''));
+        $account = $this->getAccount(null, '');
+        $this->assertSame(hash('sha256', hash('sha256', 'password', true)), $encoder->encodePassword('password', $account));
     }
 
     /**
@@ -39,6 +43,42 @@ class MessageDigestPasswordEncoderTest extends \PHPUnit_Framework_TestCase
     public function testEncodePasswordAlgorithmDoesNotExist()
     {
         $encoder = new MessageDigestPasswordEncoder('foobar');
-        $encoder->encodePassword('password', '');
+        $account = $this->getAccount(null, null);
+        $encoder->encodePassword('password', $account);
+    }
+    
+    protected function getAccount($password = null, $salt = null)
+    {
+    	$mock = $this->getMock('Symfony\Component\Security\User\AccountInterface');
+    	
+    	if (null === $password) {
+    		$mock
+    			->expects($this->never())
+    			->method('getPassword')
+    		;
+    	}
+    	else {
+    		$mock
+    			->expects($this->once())
+    			->method('getPassword')
+    			->will($this->returnValue($password))
+    		;
+    	}
+    	
+    	if (null === $salt) {
+    		$mock
+    			->expects($this->never())
+    			->method('getSalt')
+    		;
+    	}
+    	else {
+    		$mock
+    			->expects($this->once())
+    			->method('getSalt')
+    			->will($this->returnValue($salt))
+    		;
+    	}
+    	
+    	return $mock;
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Encoder/PlaintextPasswordEncoderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Encoder/PlaintextPasswordEncoderTest.php
@@ -18,21 +18,56 @@ class PlaintextPasswordEncoderTest extends \PHPUnit_Framework_TestCase
     {
         $encoder = new PlaintextPasswordEncoder();
 
-        $this->assertSame(true, $encoder->isPasswordValid('foo', 'foo', ''));
-        $this->assertSame(false, $encoder->isPasswordValid('bar', 'foo', ''));
-        $this->assertSame(false, $encoder->isPasswordValid('FOO', 'foo', ''));
+        $this->assertSame(true, $encoder->isPasswordValid('foo', $this->getAccount('foo', '')));
+        $this->assertSame(false, $encoder->isPasswordValid('foo', $this->getAccount('bar', '')));
+        $this->assertSame(false, $encoder->isPasswordValid('foo', $this->getAccount('FOO', '')));
 
         $encoder = new PlaintextPasswordEncoder(true);
 
-        $this->assertSame(true, $encoder->isPasswordValid('foo', 'foo', ''));
-        $this->assertSame(false, $encoder->isPasswordValid('bar', 'foo', ''));
-        $this->assertSame(true, $encoder->isPasswordValid('FOO', 'foo', ''));
+        $this->assertSame(true, $encoder->isPasswordValid('foo', $this->getAccount('foo', '')));
+        $this->assertSame(false, $encoder->isPasswordValid('foo', $this->getAccount('bar', '')));
+        $this->assertSame(true, $encoder->isPasswordValid('foo', $this->getAccount('FOO', '')));
     }
 
     public function testEncodePassword()
     {
         $encoder = new PlaintextPasswordEncoder();
 
-        $this->assertSame('foo', $encoder->encodePassword('foo', ''));
+        $this->assertSame('foo', $encoder->encodePassword('foo', $this->getAccount(null, '')));
+    }
+    
+    protected function getAccount($password = null, $salt = null)
+    {
+    	$mock = $this->getMock('Symfony\Component\Security\User\AccountInterface');
+    	
+    	if (null === $password) {
+    		$mock
+    			->expects($this->never())
+    			->method('getPassword')
+    		;
+    	}
+    	else {
+    		$mock
+    			->expects($this->once())
+    			->method('getPassword')
+    			->will($this->returnValue($password))
+    		;
+    	}
+    	
+    	if (null === $salt) {
+    		$mock
+    			->expects($this->never())
+    			->method('getSalt')
+    		;
+    	}
+    	else {
+    		$mock
+    			->expects($this->once())
+    			->method('getSalt')
+    			->will($this->returnValue($salt))
+    		;
+    	}
+    	
+    	return $mock;
     }
 }


### PR DESCRIPTION
This spawned off of an IRC discussion we had and should serve as a starting point for further discussion.

Basically, it gives the password encoder access to the entire user object. The downside I see is that the password encoders cannot be used without users anymore, but I guess that this wasn't intended in the first place.

What do you think?
