### PR TITLE
[HttpFoundation] Request::getContent can now return resources

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -619,10 +619,18 @@ class Request
     /**
      * Return the request body content.
      *
-     * @return string The request body content.
+     * @param bool $asResource If true, a resource will be returned
+     * @return string|resource The request body content or a resource to read the body stream.
      */
-    public function getContent()
+    public function getContent($asResource = false)
     {
+        if (false === $this->content || (true === $asResource && null !== $this->content)) {
+            throw new \LogicException('getContent can only be called once when using the resource return type');
+        }
+        if (true === $asResource) {
+            $this->content = false;
+            return fopen('php://input', 'rb');
+        }
         if (null === $this->content) {
             $this->content = file_get_contents('php://input');
         }

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -478,6 +478,42 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($file, $files['child']['sub']['file']);
     }
 
+    public function testGetContentWorksTwiceInDefaultMode()
+    {
+        $req = new Request;
+        $this->assertEquals('', $req->getContent());
+        $this->assertEquals('', $req->getContent());
+    }
+
+    public function testGetContentReturnsResource()
+    {
+        $req = new Request;
+        $retval = $req->getContent(true);
+        $this->assertType('resource', $retval);
+        $this->assertEquals("", fread($retval, 1));
+        $this->assertTrue(feof($retval));
+    }
+
+    /**
+     * @expectedException LogicException
+     * @dataProvider getContentCantBeCalledTwiceWithResourcesProvider
+     */
+    public function testGetContentCantBeCalledTwiceWithResources($first, $second)
+    {
+        $req = new Request;
+        $req->getContent($first);
+        $req->getContent($second);
+    }
+
+    public function getContentCantBeCalledTwiceWithResourcesProvider()
+    {
+        return array(
+            'Resource then fetch' => array(true, false),
+            'Resource then resource' => array(true, true),
+            'Fetch then resource' => array(false, true),
+        );
+    }
+
     protected function createTempFile()
     {
         return tempnam(sys_get_temp_dir(), 'FormTest');


### PR DESCRIPTION
As discussed in https://github.com/fabpot/symfony/commit/a7c81577c7f26cbbf34df49d200d496c91f825e2#comments
