### PR TITLE
[TwigBundle] Twig extensions

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -51,6 +51,17 @@ class TwigExtension extends Extension
 
         $container->setParameter('twig.options', array_replace($container->getParameter('twig.options'), $config));
     }
+    /**
+     * Loads the Twig_Extensions configuration.
+     *
+     * @param array            $config    An array of configuration settings
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     */
+    public function extensionsLoad($config, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, __DIR__.'/../Resources/config');
+        $loader->load('extensions.xml');
+    }
 
     /**
      * Returns the base path for the XSD files.

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/extensions.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/extensions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://www.symfony-project.org/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="twig.extension.text" class="Twig_Extensions_Extension_Text">
+            <tag name="twig.extension" />
+        </service>
+
+        <service id="twig.extension.debug" class="Twig_Extensions_Extension_Debug">
+            <tag name="twig.extension" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
This allows to easily enable Twig_Extensions. It does not enable the i18n extensions as TwigBundle defines its own TransExtension.
