### PR TITLE
Fix for : "You must configure a hydrator directory. See docs for details" 

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
@@ -20,6 +20,9 @@
     <parameter key="doctrine.odm.mongodb.proxy_namespace">Proxies</parameter>
     <parameter key="doctrine.odm.mongodb.auto_generate_proxy_classes">false</parameter>
 
+    <!-- hydrator -->
+    <parameter key="doctrine.odm.mongodb.hydrator_namespace">Hydrator</parameter>
+
     <!-- cache -->
     <parameter key="doctrine.odm.mongodb.cache.array_class">Doctrine\Common\Cache\ArrayCache</parameter>
     <parameter key="doctrine.odm.mongodb.cache.apc_class">Doctrine\Common\Cache\ApcCache</parameter>


### PR DESCRIPTION
In jwage/mongodb-odm@187170f03c1b8b730b58034ac0d5e92510d3ebda were added some exceptions that would handle the hydrator functionality in mongodb. 

Any symfony project that is using mongodb would fail with 2 type of errors 
- Doctrine\ODM\MongoDB\Hydrator\HydratorException: You must configure a hydrator directory. See docs for details
- Doctrine\ODM\MongoDB\Hydrator\HydratorException: You must configure a hydrator namespace. See docs for details

In this commit i have managed to setup the configuration needed in order to fix this functionality. 
