### PR TITLE
Routing  - speed up matching for route withou variables

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -60,17 +60,28 @@ class PhpMatcherDumper extends MatcherDumper
                 $conditions[] = sprintf("isset(\$this->context['method']) && preg_match('#^(%s)$#xi', \$this->context['method'])", $req);
             }
 
-            if ($compiledRoute->getStaticPrefix()) {
-                $conditions[] = sprintf("0 === strpos(\$url, '%s')", $compiledRoute->getStaticPrefix());
-            }
+            if (!count($compiledRoute->getVariables()) && false !== preg_match('#^(.)\^(?P<url>.*?)\$\1#', $compiledRoute->getRegex(), $m))
+            {
+                $conditions[] = sprintf("\$url === '%s'", $m['url']);
 
-            $conditions[] = sprintf("preg_match('%s', \$url, \$matches)", $compiledRoute->getRegex());
+                $matches = 'array()';
+            }
+            else
+            {
+                if ($compiledRoute->getStaticPrefix()) {
+                    $conditions[] = sprintf("0 === strpos(\$url, '%s')", $compiledRoute->getStaticPrefix());
+                }
+
+                $conditions[] = sprintf("preg_match('%s', \$url, \$matches)", $compiledRoute->getRegex());
+
+                $matches = '$matches';
+            }
 
             $conditions = implode(' && ', $conditions);
 
             $code[] = sprintf(<<<EOF
         if ($conditions) {
-            return array_merge(\$this->mergeDefaults(\$matches, %s), array('_route' => '%s'));
+            return array_merge(\$this->mergeDefaults($matches, %s), array('_route' => '%s'));
         }
 
 EOF

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
@@ -29,6 +29,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array_merge($this->mergeDefaults($matches, array ()), array('_route' => 'bar'));
         }
 
+        if ($url === '/test/baz') {
+            return array_merge($this->mergeDefaults(array(), array ()), array('_route' => 'baz'));
+        }
+
         return false;
     }
 }

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -38,6 +38,10 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array(),
             array('_method' => 'GET|head')
         ));
+        $collection->add('baz', new Route(
+            '/test/baz'
+        ));
+
         $dumper = new PhpMatcherDumper($collection);
         $this->assertStringEqualsFile(self::$fixturesPath.'/dumper/url_matcher1.php', $dumper->dump(), '->dump() dumps basic routes to the correct PHP file.');
     }


### PR DESCRIPTION
The PHP matcher matches route by using strpos & preg_match. This is not required for routes wihtout variables.

This patch uses only one comparison (`===`) when the route has no variable.
The url to match against is retrieved from the compiled route regular expression; it is the text between the the start anchor (`^`) end the end anchor (`$`).
