### PR TITLE
[Form] Making sure all validators support empty values, fixes #9297

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AssertTypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AssertTypeValidator.php
@@ -18,7 +18,7 @@ class AssertTypeValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return true;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -31,7 +31,7 @@ class ChoiceValidator extends ConstraintValidator
             throw new ConstraintDefinitionException('Either "choices" or "callback" must be specified on constraint Choice');
         }
 
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return true;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -20,7 +20,7 @@ class CollectionValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return true;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/MaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxValidator.php
@@ -19,7 +19,7 @@ class MaxValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return true;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/MinValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinValidator.php
@@ -19,7 +19,7 @@ class MinValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return true;
         }
 


### PR DESCRIPTION
This aims at fixing http://trac.symfony-project.org/ticket/9297

Only the first commit is relevant btw for this pull, I just rebased on to https://github.com/fabpot/symfony/pull/299 because it conflicts every line of this patch and I wanted to save you some trouble merging stuff.
