### PR TITLE
More intuitive matching of bundle directory lookups for Doctrine extensions

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -345,20 +345,19 @@ class DoctrineExtension extends Extension
         // configure metadata driver for each bundle based on the type of mapping files found
         $mappingDriverDef = new Definition('%doctrine.orm.metadata.driver_chain_class%');
         $bundleEntityMappings = array();
-        $bundleDirs = $container->getParameter('kernel.bundle_dirs');
         $aliasMap = array();
         foreach ($container->getParameter('kernel.bundles') as $className) {
             $tmp = dirname(str_replace('\\', '/', $className));
             $namespace = str_replace('/', '\\', dirname($tmp));
             $class = basename($tmp);
 
-            if (!isset($bundleDirs[$namespace])) {
+            if (! $bundleDir = $this->findBundleDirForNamespace($namespace, $container)) {
                 continue;
             }
 
-            $type = $this->detectMetadataDriver($bundleDirs[$namespace].'/'.$class, $container);
+            $type = $this->detectMetadataDriver($bundleDir.'/'.$class, $container);
 
-            if (is_dir($dir = $bundleDirs[$namespace].'/'.$class.'/Entity')) {
+            if (is_dir($dir = $bundleDir.'/'.$class.'/Entity')) {
                 if (null === $type) {
                     $type = 'annotation';
                 }
@@ -458,6 +457,31 @@ class DoctrineExtension extends Extension
             $cacheDef = new Definition('%'.sprintf('doctrine.orm.cache.%s_class', $type).'%');
         }
         return $cacheDef;
+    }
+
+    /**
+     * Finds the bundle directory for a namespace.
+     *
+     * If the namespace does not yield a direct match, this method will attempt
+     * to match parent namespaces exhaustively.
+     *
+     * @param string           $namespace A bundle namespace omitting the bundle name part
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     *
+     * @return string|false The bundle directory if found, false otherwise
+     */
+    protected function findBundleDirForNamespace($namespace, ContainerBuilder $container)
+    {
+        $bundleDirs = $container->getParameter('kernel.bundle_dirs');
+        $segment = $namespace;
+
+        do {
+            if (isset($bundleDirs[$segment])) {
+                return $bundleDirs[$segment] . str_replace('\\', '/', substr($namespace, strlen($segment)));
+            }
+        } while ($segment = substr($segment, 0, ($pos = strrpos($segment, '\\'))));
+
+        return false;
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -391,6 +391,24 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Entity', $calls[0][1][1]);
     }
 
+    public function testAnnotationsBundleMappingDetectionWithVendorNamespace()
+    {
+        $container = $this->getContainer('AnnotationsBundle', 'Vendor');
+        $loader = new DoctrineExtension();
+
+        $loader->dbalLoad(array(), $container);
+        $loader->ormLoad(array(), $container);
+
+        $this->assertEquals(array(), $container->getParameter('doctrine.orm.metadata_driver.mapping_dirs'));
+        $this->assertEquals('%doctrine.orm.metadata_driver.mapping_dirs%', $container->getParameter('doctrine.orm.xml_mapping_dirs'));
+        $this->assertEquals('%doctrine.orm.metadata_driver.mapping_dirs%', $container->getParameter('doctrine.orm.yml_mapping_dirs'));
+        $this->assertEquals(array(__DIR__.'/Fixtures/Bundles/Vendor/AnnotationsBundle/Entity'), $container->getParameter('doctrine.orm.metadata_driver.entity_dirs'));
+
+        $calls = $container->getDefinition('doctrine.orm.metadata_driver')->getMethodCalls();
+        $this->assertEquals('doctrine.orm.metadata_driver.annotation', (string) $calls[0][1][0]);
+        $this->assertEquals('DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\Vendor\AnnotationsBundle\Entity', $calls[0][1][1]);
+    }
+
     public function testEntityManagerMetadataCacheDriverConfiguration()
     {
         $container = $this->getContainer();
@@ -448,13 +466,13 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertTrue($container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
     }
 
-    protected function getContainer($bundle = 'YamlBundle')
+    protected function getContainer($bundle = 'YamlBundle', $vendor = null)
     {
-        require_once __DIR__.'/Fixtures/Bundles/'.$bundle.'/'.$bundle.'.php';
+        require_once __DIR__.'/Fixtures/Bundles/'.($vendor ? $vendor.'/' : '').$bundle.'/'.$bundle.'.php';
 
         return new ContainerBuilder(new ParameterBag(array(
             'kernel.bundle_dirs' => array('DoctrineBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles' => __DIR__.'/Fixtures/Bundles'),
-            'kernel.bundles'     => array('DoctrineBundle\\Tests\DependencyInjection\\Fixtures\\Bundles\\'.$bundle.'\\'.$bundle),
+            'kernel.bundles'     => array('DoctrineBundle\\Tests\DependencyInjection\\Fixtures\\Bundles\\'.($vendor ? $vendor.'\\' : '').$bundle.'\\'.$bundle),
             'kernel.cache_dir'   => sys_get_temp_dir(),
         )));
     }

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/AnnotationsBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/AnnotationsBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\Vendor\AnnotationsBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AnnotationsBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/Entity/Test.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/Entity/Test.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\Vendor\AnnotationsBundle\Entity;
+
+class Test
+{
+}

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -246,20 +246,19 @@ class DoctrineMongoDBExtension extends Extension
         // configure metadata driver for each bundle based on the type of mapping files found
         $mappingDriverDef = new Definition('%doctrine.odm.mongodb.metadata.driver_chain_class%');
         $bundleDocumentMappings = array();
-        $bundleDirs = $container->getParameter('kernel.bundle_dirs');
         $aliasMap = array();
         foreach ($container->getParameter('kernel.bundles') as $className) {
             $tmp = dirname(str_replace('\\', '/', $className));
             $namespace = str_replace('/', '\\', dirname($tmp));
             $class = basename($tmp);
 
-            if (!isset($bundleDirs[$namespace])) {
+            if (! $bundleDir = $this->findBundleDirForNamespace($namespace, $container)) {
                 continue;
             }
 
-            $type = $this->detectMetadataDriver($bundleDirs[$namespace].'/'.$class, $container);
+            $type = $this->detectMetadataDriver($bundleDir.'/'.$class, $container);
 
-            if (is_dir($dir = $bundleDirs[$namespace].'/'.$class.'/Document')) {
+            if (is_dir($dir = $bundleDir.'/'.$class.'/Document')) {
                 if (null === $type) {
                     $type = 'annotation';
                 }
@@ -351,6 +350,31 @@ class DoctrineMongoDBExtension extends Extension
             $connections = array($defaultConnection => $config);
         }
         return $connections;
+    }
+
+    /**
+     * Finds the bundle directory for a namespace.
+     *
+     * If the namespace does not yield a direct match, this method will attempt
+     * to match parent namespaces exhaustively.
+     *
+     * @param string           $namespace A bundle namespace omitting the bundle name part
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     *
+     * @return string|false The bundle directory if found, false otherwise
+     */
+    protected function findBundleDirForNamespace($namespace, ContainerBuilder $container)
+    {
+        $bundleDirs = $container->getParameter('kernel.bundle_dirs');
+        $segment = $namespace;
+
+        do {
+            if (isset($bundleDirs[$segment])) {
+                return $bundleDirs[$segment] . str_replace('\\', '/', substr($namespace, strlen($segment)));
+            }
+        } while ($segment = substr($segment, 0, ($pos = strrpos($segment, '\\'))));
+
+        return false;
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -266,6 +266,23 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Document', $calls[0][1][1]);
     }
 
+    public function testAnnotationsBundleMappingDetectionWithVendorNamespace()
+    {
+        $container = $this->getContainer('AnnotationsBundle', 'Vendor');
+        $loader = new DoctrineMongoDBExtension();
+
+        $loader->mongodbLoad(array(), $container);
+
+        $this->assertEquals(array(), $container->getParameter('doctrine.odm.mongodb.mapping_dirs'));
+        $this->assertEquals('%doctrine.odm.mongodb.mapping_dirs%', $container->getParameter('doctrine.odm.mongodb.xml_mapping_dirs'));
+        $this->assertEquals('%doctrine.odm.mongodb.mapping_dirs%', $container->getParameter('doctrine.odm.mongodb.yml_mapping_dirs'));
+        $this->assertEquals(array(__DIR__.'/Fixtures/Bundles/Vendor/AnnotationsBundle/Document'), $container->getParameter('doctrine.odm.mongodb.document_dirs'));
+
+        $calls = $container->getDefinition('doctrine.odm.mongodb.metadata')->getMethodCalls();
+        $this->assertEquals('doctrine.odm.mongodb.metadata.annotation', (string) $calls[0][1][0]);
+        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\Vendor\AnnotationsBundle\Document', $calls[0][1][1]);
+    }
+
     public function testDocumentManagerMetadataCacheDriverConfiguration()
     {
         $container = $this->getContainer();
@@ -323,13 +340,13 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $this->assertTrue($container->getParameter('doctrine.odm.mongodb.auto_generate_proxy_classes'));
     }
 
-    protected function getContainer($bundle = 'YamlBundle')
+    protected function getContainer($bundle = 'YamlBundle', $vendor = null)
     {
-        require_once __DIR__.'/Fixtures/Bundles/'.$bundle.'/'.$bundle.'.php';
+        require_once __DIR__.'/Fixtures/Bundles/'.($vendor ? $vendor.'/' : '').$bundle.'/'.$bundle.'.php';
 
         return new ContainerBuilder(new ParameterBag(array(
             'kernel.bundle_dirs' => array('DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles' => __DIR__.'/Fixtures/Bundles'),
-            'kernel.bundles'     => array('DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles\\'.$bundle.'\\'.$bundle),
+            'kernel.bundles'     => array('DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles\\'.($vendor ? $vendor.'\\' : '').$bundle.'\\'.$bundle),
             'kernel.cache_dir'   => sys_get_temp_dir(),
         )));
     }

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/AnnotationsBundle.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/AnnotationsBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\Vendor\AnnotationsBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AnnotationsBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/Document/Test.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/Bundles/Vendor/AnnotationsBundle/Document/Test.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\Vendor\AnnotationsBundle\Document;
+
+class Test
+{
+}


### PR DESCRIPTION
See commit message. This solves a problem that the FOS\UserBundle had with the Doctrine extensions loading their mapping files, due to the "FOS" vendor segment in their namespace/directory path.

I believe this is an intuitive solution for the application developer, as it removes the necessity to define each vendor explicitly in the kernel's registerBundleDirs() method.

I'm not sure if FrameworkBundle or others have similar problems looking up directors for vendor-organized bundles, but perhaps this code could be useful outside of just the Doctrine extensions.
