### PR TITLE
Form->getUri() should return it's path if no action is defined

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -171,6 +171,10 @@ class Form implements \ArrayAccess
         $uri = $this->node->getAttribute('action');
         $urlHaveScheme = 'http' === substr($uri, 0, 4);
 
+        if(!$uri) {
+            $uri = $this->path;
+        }
+
         if (!in_array($this->getMethod(), array('post', 'put', 'delete')) && $queryString = http_build_query($this->getValues(), null, '&')) {
             $sep = false === strpos($uri, '?') ? '?' : '&';
             $uri .= $sep.$queryString;

--- a/tests/Symfony/Tests/Component/DomCrawler/FormTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/FormTest.php
@@ -288,6 +288,14 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/foo/bar?get=param', $form->getUri(false), '->getUri() returns absolute URIs only if the host has been defined in the constructor');
     }
 
+    public function testGetUriWithoutAction()
+    {
+        $form = $this->createForm('<form><input type="submit" /></form>', null, 'http://localhost', '/foo/bar');
+        $this->assertEquals('http://localhost/foo/bar', $form->getUri(true), '->getUri() returns path if no action defined');
+
+        $this->assertEquals('/foo/bar', $form->getUri(false), '->getUri() returns path if no action defined');
+    }
+
     public function provideGetUriValues()
     {
         return array(
@@ -325,7 +333,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
                 'returns an empty URI if the action is empty',
                 '<form><input type="submit" /></form>',
                 array(),
-                '',
+                '/',
             ),
             array(
                 'appends the form values even if the action is empty',


### PR DESCRIPTION
When trying Goutte on a certain website, I ran into a problem when there was no action (`<form>` or `<form action=''>`) defined. Turns out that DomCrawler\Form does not return a correct URI when there is no action defined. There is some testcase for that specific situation, but it is incorrect and not complete. My commit includes an extra testcase, repairs the broken testcase and -not the least- proposes a fix for the problem explained here.
