### PR TITLE
[Console] fixed call to undefined method.

### DIFF
--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -102,7 +102,7 @@ class Shell
 
         // options and arguments?
         try {
-            $command = $this->application->findCommand(substr($text, 0, strpos($text, ' ')));
+            $command = $this->application->find(substr($text, 0, strpos($text, ' ')));
         } catch (\Exception $e) {
             return true;
         }


### PR DESCRIPTION
fixed call to undefined method `Application::findCommand()` in Shell::autocompleter().
`Application::find()` is correct.
