### PR TITLE
Fix reference to ODM extension's annotation reader

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -567,7 +567,7 @@ class DoctrineMongoDBExtension extends Extension
         foreach ($this->drivers as $driverType => $driverPaths) {
             if ($driverType == 'annotation') {
                 $mappingDriverDef = new Definition('%'.$this->getObjetManagerElementName('metadata.' . $driverType . '_class%'), array(
-                    new Reference($this->getObjetManagerElementName('metadata_driver.annotation.reader')),
+                    new Reference($this->getObjetManagerElementName('metadata.annotation_reader')),
                     array_values($driverPaths)
                 ));
             } else {


### PR DESCRIPTION
Fixes a bad reference to ODM's annotation reader service.

This showed up after the Doctrine extensions were refactored in https://github.com/fabpot/symfony/pull/264
