### PR TITLE
[SwiftmailerBundle] Fixed typo and fixed InvalidArgumentException

### DIFF
--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -95,9 +95,11 @@ class SwiftMailerExtension extends Extension
             $config['delivery_address'] = $config['delivery-address'];
         }
 
-        if (isset($config['delivery_address'])) {
+        if (isset($config['delivery_address']) && $config['delivery_address']) {
             $container->setParameter('swiftmailer.single_address', $config['delivery_address']);
             $container->findDefinition('swiftmailer.transport')->addMethodCall('registerPlugin', array(new Reference('swiftmailer.plugin.redirecting')));
+        } else {
+            $container->setParameter('swiftmailer.single_address', null);
         }
 
         if (array_key_exists('disable-delivery', $config)) {


### PR DESCRIPTION
Fixed commit c9f08c0a68446ef27e5ec089c9ec5b85ba78b35a

If the configuration does not specify 'disable_delivery', then an InvalidArgumentException is returned because 'swiftmailer.single_address' is not set.
