### PR TITLE
Container optimization

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -439,7 +439,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             new Reference('doctrine.orm.default_annotation_metadata_driver'),
             'DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Entity'
         ));
-        
+
         $configDef = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($configDef, 'setAutoGenerateProxyClasses', array(false));
     }
@@ -505,12 +505,13 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
     public function testSingleEntityManagerMultipleMappingBundleDefinitions()
     {
         $container = $this->getContainer(array('YamlBundle', 'AnnotationsBundle', 'XmlBundle'));
-        
+
         $loader = new DoctrineExtension();
         $container->registerExtension($loader);
 
         $this->loadFromFile($container, 'orm_single_em_bundle_mappings');
 
+        $container->getCompilerPassConfig()->setRemovingPasses(array());
         $container->freeze();
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
@@ -556,6 +557,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $this->loadFromFile($container, 'orm_multiple_em_bundle_mappings');
 
+        $container->getCompilerPassConfig()->setRemovingPasses(array());
         $container->freeze();
 
         $def1 = $container->getDefinition('doctrine.orm.em1_metadata_driver');
@@ -628,7 +630,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     /**
      * Assertion on the Class of a DIC Service Definition.
-     * 
+     *
      * @param \Symfony\Component\DependencyInjection\Definition $definition
      * @param string $expectedClass
      */

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class AddConstraintValidatorsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('validator.validator_factory')) {
+            return;
+        }
+
+        $validators = array();
+        foreach ($container->findTaggedServiceIds('validator.constraint_validator') as $id => $attributes) {
+            if (isset($attributes[0]['alias'])) {
+                $validators[$attributes[0]['alias']] = $id;
+            }
+        }
+
+        $definition = $container->getDefinition('validator.validator_factory');
+        $arguments = $definition->getArguments();
+        $arguments[1] = $validators;
+        $definition->setArguments($arguments);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddTemplatingRenderersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddTemplatingRenderersPass.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class AddTemplatingRenderersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('templating.engine')) {
+            return;
+        }
+
+        $renderers = array();
+        foreach ($container->findTaggedServiceIds('templating.renderer') as $id => $attributes) {
+            if (isset($attributes[0]['alias'])) {
+                $renderers[$attributes[0]['alias']] = new Reference($id);
+                $container->getDefinition($id)->addMethodCall('setEngine', array(new Reference('templating.engine')));
+            }
+        }
+
+        $helpers = array();
+        foreach ($container->findTaggedServiceIds('templating.helper') as $id => $attributes) {
+            if (isset($attributes[0]['alias'])) {
+                $helpers[$attributes[0]['alias']] = $id;
+            }
+        }
+
+        $definition = $container->getDefinition('templating.engine');
+        $arguments = $definition->getArguments();
+        $arguments[2] = $renderers;
+        $definition->setArguments($arguments);
+
+        if (count($helpers) > 0) {
+            $definition->addMethodCall('setHelpers', array($helpers));
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class RegisterKernelListenersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('event_dispatcher')) {
+            return;
+        }
+
+        $listeners = array();
+        foreach ($container->findTaggedServiceIds('kernel.listener') as $id => $attributes) {
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+
+            if (!isset($listeners[$priority])) {
+                $listeners[$priority] = array();
+            }
+
+            $listeners[$priority][] = new Reference($id);
+        }
+
+        $container
+            ->getDefinition('event_dispatcher')
+            ->addMethodCall('registerKernelListeners', array($listeners))
+        ;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/EventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventDispatcher.php
@@ -3,7 +3,6 @@
 namespace Symfony\Bundle\FrameworkBundle;
 
 use Symfony\Component\EventDispatcher\EventDispatcher as BaseEventDispatcher;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /*
  * This file is part of the Symfony package.
@@ -15,18 +14,18 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 
 /**
- * This EventDispatcher implementation uses a DependencyInjection container to load listeners.
+ * This EventDispatcher automatically gets the kernel listeners injected
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  */
 class EventDispatcher extends BaseEventDispatcher
 {
-    public function setContainer(ContainerInterface $container)
+    public function registerKernelListeners(array $kernelListeners)
     {
-        foreach ($container->findTaggedServiceIds('kernel.listener') as $id => $attributes) {
-            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
-
-            $container->get($id)->register($this, $priority);
+        foreach ($kernelListeners as $priority => $listeners) {
+            foreach ($listeners as $listener) {
+                $listener->register($this, $priority);
+            }
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -2,6 +2,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle;
 
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddTemplatingRenderersPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RegisterKernelListenersPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConverterManagerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RoutingResolverPass;
@@ -60,5 +62,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new ConverterManagerPass());
         $container->addCompilerPass(new RoutingResolverPass());
         $container->addCompilerPass(new ProfilerPass());
+        $container->addCompilerPass(new RegisterKernelListenersPass());
+        $container->addCompilerPass(new AddTemplatingRenderersPass());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -11,9 +11,6 @@
     <services>
         <service id="debug.event_dispatcher" class="%debug.event_dispatcher.class%">
             <argument type="service" id="logger" on-invalid="null" />
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -14,12 +14,9 @@
 
     <services>
         <service id="event_dispatcher" class="%event_dispatcher.class%">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
         </service>
 
-        <service id="error_handler" class="%error_handler.class%">
+        <service id="error_handler" class="%error_handler.class%" public="false">
             <argument>%error_handler.level%</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -27,18 +27,15 @@
             <argument type="service" id="validator.validator_factory" />
         </service>
 
-        <service id="validator.mapping.class_metadata_factory" class="%validator.mapping.class_metadata_factory.class%">
+        <service id="validator.mapping.class_metadata_factory" class="%validator.mapping.class_metadata_factory.class%" public="false">
             <argument type="service" id="validator.mapping.loader.loader_chain" />
         </service>
 
-        <service id="validator.validator_factory" class="%validator.validator_factory.class%">
+        <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">
             <argument type="service" id="service_container" />
-            <call method="loadTaggedServiceIds">
-                <argument type="service" id="service_container" />
-            </call>
         </service>
 
-        <service id="validator.mapping.loader.loader_chain" class="%validator.mapping.loader.loader_chain.class%">
+        <service id="validator.mapping.loader.loader_chain" class="%validator.mapping.loader.loader_chain.class%" public="false">
             <argument type="collection">
                 <argument type="service" id="validator.mapping.loader.static_method_loader" />
                 <argument type="service" id="validator.mapping.loader.xml_files_loader" />
@@ -46,7 +43,7 @@
             </argument>
         </service>
 
-        <service id="validator.mapping.loader.static_method_loader" class="%validator.mapping.loader.static_method_loader.class%">
+        <service id="validator.mapping.loader.static_method_loader" class="%validator.mapping.loader.static_method_loader.class%" public="false">
             <argument>%validator.mapping.loader.static_method_loader.method_name%</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Engine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Engine.php
@@ -28,28 +28,15 @@ class Engine extends BaseEngine
     /**
      * Constructor.
      *
-     * @param ContainerInterface $container A ContainerInterface instance
+     * @param ContainerInterface $container The DI container
      * @param LoaderInterface    $loader    A loader instance
+     * @param array              $renderers All templating renderers
      */
-    public function __construct(ContainerInterface $container, LoaderInterface $loader)
+    public function __construct(ContainerInterface $container, LoaderInterface $loader, array $renderers)
     {
         $this->container = $container;
 
-        parent::__construct($loader);
-
-        foreach ($this->container->findTaggedServiceIds('templating.renderer') as $id => $attributes) {
-            if (isset($attributes[0]['alias'])) {
-                $this->renderers[$attributes[0]['alias']] = $this->container->get($id);
-                $this->renderers[$attributes[0]['alias']]->setEngine($this);
-            }
-        }
-
-        $this->helpers = array();
-        foreach ($this->container->findTaggedServiceIds('templating.helper') as $id => $attributes) {
-            if (isset($attributes[0]['alias'])) {
-                $this->helpers[$attributes[0]['alias']] = $id;
-            }
-        }
+        parent::__construct($loader, $renderers);
     }
 
     public function getContainer()
@@ -97,6 +84,11 @@ class Engine extends BaseEngine
         }
 
         return $this->helpers[$name];
+    }
+
+    public function setHelpers(array $helpers)
+    {
+        $this->helpers = $helpers;
     }
 
     // parses template names following the following pattern:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/EngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/EngineTest.php
@@ -30,7 +30,7 @@ class EngineTest extends TestCase
      */
     public function testSplitTemplateName($name, $parameters)
     {
-        $engine = new Engine($this->getContainerMock(), $this->getLoaderMock());
+        $engine = new Engine($this->getContainerMock(), $this->getLoaderMock(), array());
 
         $this->assertEquals($parameters, $engine->splitTemplateName($name));
     }
@@ -50,7 +50,7 @@ class EngineTest extends TestCase
      */
     public function testSplitTemplateNameInvalid($name)
     {
-        $engine = new Engine($this->getContainerMock(), $this->getLoaderMock());
+        $engine = new Engine($this->getContainerMock(), $this->getLoaderMock(), array());
 
         $engine->splitTemplateName($name);
     }
@@ -75,11 +75,6 @@ class EngineTest extends TestCase
         ;
 
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
-        $container
-            ->expects($this->exactly(2))
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue(array()))
-        ;
         $container
             ->expects($this->any())
             ->method('get')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
@@ -49,13 +49,6 @@ class ConstraintValidatorFactoryTest extends \PHPUnit_Framework_TestCase
         $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
         $container
             ->expects($this->once())
-            ->method('findTaggedServiceIds')
-            ->with('validator.constraint_validator')
-            ->will($this->returnValue(array(
-                $service => array(array('alias' => $alias)),
-            )));
-        $container
-            ->expects($this->once())
             ->method('get')
             ->with($service)
             ->will($this->returnValue($validator));
@@ -66,8 +59,7 @@ class ConstraintValidatorFactoryTest extends \PHPUnit_Framework_TestCase
             ->method('validatedBy')
             ->will($this->returnValue($alias));
 
-        $factory = new ConstraintValidatorFactory($container);
-        $factory->loadTaggedServiceIds($container);
+        $factory = new ConstraintValidatorFactory($container, array('validator_constraint_alias' => 'validator_constraint_service'));
         $this->assertSame($validator, $factory->getInstance($constraint));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
@@ -39,30 +39,17 @@ use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
 {
     protected $container;
-    protected $validators = array();
+    protected $validators;
 
     /**
      * Constructor.
      *
      * @param ContainerInterface $container The service container
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, array $validators = array())
     {
         $this->container = $container;
-    }
-
-    /**
-     * Loads ids for services tagged as constraint validators.
-     *
-     * @param TaggedContainerInterface $container The tagged service container
-     */
-    public function loadTaggedServiceIds(TaggedContainerInterface $container)
-    {
-        foreach ($container->findTaggedServiceIds('validator.constraint_validator') as $id => $attributes) {
-            if (isset($attributes[0]['alias'])) {
-                $this->validators[$attributes[0]['alias']] = $id;
-            }
-        }
+        $this->validators = $validators;
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
@@ -38,7 +38,7 @@ class TemplatingExtension extends \Twig_Extension
 
     public function getTemplating()
     {
-        return $this->container->get('templating.engine');
+        return $this->container->get('templating');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Inline service definitions where this is possible.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class InlineServiceDefinitionsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $definition->setArguments(
+                $this->inlineArguments($container, $definition->getArguments())
+            );
+
+            $definition->setMethodCalls(
+                $this->inlineArguments($container, $definition->getMethodCalls())
+            );
+        }
+    }
+
+    protected function inlineArguments(ContainerBuilder $container, array $arguments)
+    {
+        foreach ($arguments as $k => $argument) {
+            if (is_array($argument)) {
+                $arguments[$k] = $this->inlineArguments($container, $argument);
+            } else if ($argument instanceof Reference) {
+                if (!$container->hasDefinition($id = (string) $argument)) {
+                    continue;
+                }
+
+                if ($this->isInlinableDefinition($container, $id, $definition = $container->getDefinition($id))) {
+                    $arguments[$k] = $definition;
+                }
+            }
+        }
+
+        return $arguments;
+    }
+
+    protected function isInlinableDefinition(ContainerBuilder $container, $id, Definition $definition)
+    {
+        if (!$definition->isShared()) {
+            return true;
+        }
+
+        if ($definition->isPublic()) {
+            return false;
+        }
+
+        $references = count(array_keys($container->getAliases(), $id, true));
+        foreach ($container->getDefinitions() as $cDefinition)
+        {
+            if ($references > 1) {
+                break;
+            }
+
+            if ($this->isReferencedByArgument($id, $cDefinition->getArguments())) {
+                $references += 1;
+                continue;
+            }
+
+            foreach ($cDefinition->getMethodCalls() as $call) {
+                if ($this->isReferencedByArgument($id, $call[1])) {
+                    $references += 1;
+                    continue 2;
+                }
+            }
+        }
+
+        return $references <= 1;
+    }
+
+    protected function isReferencedByArgument($id, $argument)
+    {
+        if (is_array($argument)) {
+            foreach ($argument as $arg) {
+                if ($this->isReferencedByArgument($id, $arg)) {
+                    return true;
+                }
+            }
+        } else if ($argument instanceof Reference) {
+            if ($id === (string) $argument) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -31,10 +31,13 @@ class PassConfig
 
         $this->optimizationPasses = array(
             new ResolveParameterPlaceHoldersPass(),
+            new ResolveReferencesToAliasesPass(),
             new ResolveInterfaceInjectorsPass(),
+            new ResolveInvalidReferencesPass(),
         );
 
         $this->removingPasses = array(
+            new InlineServiceDefinitionsPass(),
             new RemoveUnusedDefinitionsPass(),
         );
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Emulates the invalid behavior if the reference is not found within the
+ * container.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ResolveInvalidReferencesPass implements CompilerPassInterface
+{
+    protected $container;
+    protected $exceptions;
+
+    public function __construct(array $exceptions = array('kernel', 'service_container', 'templating.loader.wrapped', 'pdo_connection'))
+    {
+        $this->exceptions = $exceptions;
+    }
+
+    public function addException($id)
+    {
+        $this->exceptions[] = $id;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->container = $container;
+        foreach ($container->getDefinitions() as $definition) {
+            $definition->setArguments(
+                $this->processArguments($definition->getArguments())
+            );
+
+            $calls = array();
+            foreach ($definition->getMethodCalls() as $k => $call) {
+                try {
+                    $calls[$k] = $this->processArguments($call, true);
+                } catch (\RuntimeException $ignore) {
+                    // this call is simply removed
+                }
+            }
+            $definition->setMethodCalls($calls);
+        }
+    }
+
+    protected function processArguments(array $arguments, $inMethodCall = false)
+    {
+        foreach ($arguments as $k => $argument) {
+            if (is_array($argument)) {
+                $arguments[$k] = $this->processArguments($argument, $inMethodCall);
+            } else if ($argument instanceof Reference) {
+                $id = (string) $argument;
+
+                if (in_array($id, $this->exceptions, true)) {
+                    continue;
+                }
+
+                $invalidBehavior = $argument->getInvalidBehavior();
+                $exists = $this->container->has($id);
+
+                if ($exists && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
+                    $arguments[$k] = new Reference($id);
+                } else if (!$exists && ContainerInterface::NULL_ON_INVALID_REFERENCE === $invalidBehavior) {
+                    $arguments[$k] = null;
+                } else if (!$exists && ContainerInterface::IGNORE_ON_INVALID_REFERENCE === $invalidBehavior) {
+                    if ($inMethodCall) {
+                        throw new \RuntimeException('Method shouldn\'t be called.');
+                    }
+
+                    $arguments[$k] = null;
+                }
+            }
+        }
+
+        return $arguments;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Replaces all references to aliases with references to the actual service.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ResolveReferencesToAliasesPass implements CompilerPassInterface
+{
+    protected $container;
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->container = $container;
+
+        foreach ($container->getDefinitions() as $id => $definition)
+        {
+            $definition->setArguments($this->processArguments($definition->getArguments()));
+            $definition->setMethodCalls($this->processArguments($definition->getMethodCalls()));
+        }
+    }
+
+    protected function processArguments(array $arguments)
+    {
+        foreach ($arguments as $k => $argument) {
+            if (is_array($argument)) {
+                $arguments[$k] = $this->processArguments($argument);
+            } else if ($argument instanceof Reference) {
+                $defId = $this->getDefinitionId($id = (string) $argument);
+
+                if ($defId !== $id) {
+                    $arguments[$k] = new Reference($defId, $argument->getInvalidBehavior());
+                }
+            }
+        }
+
+        return $arguments;
+    }
+
+    protected function getDefinitionId($id)
+    {
+        if ($this->container->hasAlias($id)) {
+            return $this->getDefinitionId($this->container->getAlias($id));
+        }
+
+        return $id;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Variable.php
+++ b/src/Symfony/Component/DependencyInjection/Variable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection;
+
+class Variable
+{
+    protected $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPassTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Symfony\Tests\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('inlinable.service')
+            ->setPublic(false)
+        ;
+
+        $container
+            ->register('service')
+            ->setArguments(array(new Reference('inlinable.service')))
+        ;
+
+        $this->process($container);
+
+        $arguments = $container->getDefinition('service')->getArguments();
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Definition', $arguments[0]);
+        $this->assertSame($container->getDefinition('inlinable.service'), $arguments[0]);
+    }
+
+    public function testProcessDoesNotInlinesWhenAliasedServiceIsNotShared()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setPublic(false)
+        ;
+        $container->setAlias('moo', 'foo');
+
+        $container
+            ->register('service')
+            ->setArguments(array($ref = new Reference('foo')))
+        ;
+
+        $this->process($container);
+
+        $arguments = $container->getDefinition('service')->getArguments();
+        $this->assertSame($ref, $arguments[0]);
+    }
+
+    public function testProcessDoesInlineNonSharedService()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setShared(false)
+        ;
+        $container
+            ->register('bar')
+            ->setPublic(false)
+            ->setShared(false)
+        ;
+        $container->setAlias('moo', 'bar');
+
+        $container
+            ->register('service')
+            ->setArguments(array(new Reference('foo'), $ref = new Reference('moo'), new Reference('bar')))
+        ;
+
+        $this->process($container);
+
+        $arguments = $container->getDefinition('service')->getArguments();
+        $this->assertSame($container->getDefinition('foo'), $arguments[0]);
+        $this->assertSame($ref, $arguments[1]);
+        $this->assertSame($container->getDefinition('bar'), $arguments[2]);
+    }
+
+    protected function process(ContainerBuilder $container)
+    {
+        $pass = new InlineServiceDefinitionsPass();
+        $pass->process($container);
+    }
+}

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPassTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Symfony\Tests\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RemoveUnusedDefinitionsPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setPublic(false)
+        ;
+        $container
+            ->register('bar')
+            ->setPublic(false)
+        ;
+        $container
+            ->register('moo')
+            ->setArguments(array(new Reference('bar')))
+        ;
+
+        $this->process($container);
+
+        $this->assertFalse($container->hasDefinition('foo'));
+        $this->assertTrue($container->hasDefinition('bar'));
+        $this->assertTrue($container->hasDefinition('moo'));
+    }
+
+    public function testProcessRemovesUnusedDefinitionsRecursively()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setPublic(false)
+        ;
+        $container
+            ->register('bar')
+            ->setArguments(array(new Reference('foo')))
+            ->setPublic(false)
+        ;
+
+        $this->process($container);
+
+        $this->assertFalse($container->hasDefinition('foo'));
+        $this->assertFalse($container->hasDefinition('bar'));
+    }
+
+    public function testProcessWorksWithInlinedDefinitions()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setPublic(false)
+        ;
+        $container
+            ->register('bar')
+            ->setArguments(array(new Definition(null, array(new Reference('foo')))))
+        ;
+
+        $this->process($container);
+
+        $this->assertTrue($container->hasDefinition('foo'));
+        $this->assertTrue($container->hasDefinition('bar'));
+    }
+
+    protected function process(ContainerBuilder $container)
+    {
+        $pass = new RemoveUnusedDefinitionsPass();
+        $pass->process($container);
+    }
+}

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Symfony\Tests\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+use Symfony\Component\DependencyInjection\Reference;
+
+use Symfony\Component\DependencyInjection\Compiler\ResolveInvalidReferencesPass;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ResolveInvalidReferencesPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $def = $container
+            ->register('foo')
+            ->setArguments(array(new Reference('bar', ContainerInterface::NULL_ON_INVALID_REFERENCE)))
+            ->addMethodCall('foo', array(new Reference('moo', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
+        ;
+
+        $this->process($container);
+
+        $arguments = $def->getArguments();
+        $this->assertNull($arguments[0]);
+        $this->assertEquals(0, count($def->getMethodCalls()));
+    }
+
+    public function testProcessIgnoreNonExistentServices()
+    {
+        $container = new ContainerBuilder();
+        $def = $container
+            ->register('foo')
+            ->setArguments(array(new Reference('bar')))
+        ;
+
+        $this->process($container);
+
+        $arguments = $def->getArguments();
+        $this->assertEquals('bar', (string) $arguments[0]);
+    }
+
+    public function testProcessIgnoresExceptions()
+    {
+        $container = new ContainerBuilder();
+        $def = $container
+            ->register('foo')
+            ->setArguments(array(new Reference('bar', ContainerInterface::NULL_ON_INVALID_REFERENCE)))
+        ;
+
+        $this->process($container, array('bar'));
+
+        $arguments = $def->getArguments();
+        $this->assertEquals('bar', (string) $arguments[0]);
+    }
+
+    protected function process(ContainerBuilder $container, array $exceptions = array())
+    {
+        $pass = new ResolveInvalidReferencesPass($exceptions);
+        $pass->process($container);
+    }
+}

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPassTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Tests\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Compiler\ResolveReferencesToAliasesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ResolveReferencesToAliasesPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->setAlias('bar', 'foo');
+        $def = $container
+            ->register('moo')
+            ->setArguments(array(new Reference('bar')))
+        ;
+
+        $this->process($container);
+
+        $arguments = $def->getArguments();
+        $this->assertEquals('foo', (string) $arguments[0]);
+    }
+
+    public function testProcessRecursively()
+    {
+        $container = new ContainerBuilder();
+        $container->setAlias('bar', 'foo');
+        $container->setAlias('moo', 'bar');
+        $def = $container
+            ->register('foobar')
+            ->setArguments(array(new Reference('moo')))
+        ;
+
+        $this->process($container);
+
+        $arguments = $def->getArguments();
+        $this->assertEquals('foo', (string) $arguments[0]);
+    }
+
+    protected function process(ContainerBuilder $container)
+    {
+        $pass = new ResolveReferencesToAliasesPass();
+        $pass->process($container);
+    }
+}

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/containers/container9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/containers/container9.php
@@ -42,8 +42,8 @@ $container->
     register('method_call1', 'FooClass')->
     setFile(realpath(__DIR__.'/../includes/foo.php'))->
     addMethodCall('setBar', array(new Reference('foo')))->
-    addMethodCall('setBar', array(new Reference('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE)))->
-    addMethodCall('setBar', array(new Reference('foo', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))->
+    addMethodCall('setBar', array(new Reference('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE)))->
+    addMethodCall('setBar', array(new Reference('foo3', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))->
     addMethodCall('setBar', array(new Reference('foobaz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
 ;
 $container->

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/graphviz/services9.dot
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/graphviz/services9.dot
@@ -10,13 +10,15 @@ digraph sc {
   node_method_call1 [label="method_call1\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_factory_service [label="factory_service\n\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
+  node_foo2 [label="foo2\n\n", shape=record, fillcolor="#ff9999", style="filled"];
+  node_foo3 [label="foo3\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foobaz [label="foobaz\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foo -> node_foo_baz [label="" style="filled"];
   node_foo -> node_service_container [label="" style="filled"];
   node_foo -> node_bar [label="setBar()" style="dashed"];
   node_bar -> node_foo_baz [label="" style="filled"];
   node_method_call1 -> node_foo [label="setBar()" style="dashed"];
-  node_method_call1 -> node_foo [label="setBar()" style="dashed"];
-  node_method_call1 -> node_foo [label="setBar()" style="dashed"];
+  node_method_call1 -> node_foo2 [label="setBar()" style="dashed"];
+  node_method_call1 -> node_foo3 [label="setBar()" style="dashed"];
   node_method_call1 -> node_foobaz [label="setBar()" style="dashed"];
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
@@ -31,6 +31,7 @@ class ProjectServiceContainer extends Container implements TaggedContainerInterf
     protected function getFooService()
     {
         $instance = call_user_func(array('FooClass', 'getInstance'), 'foo', $this->get('foo.baz'), array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo'), 'bar' => $this->getParameter('foo')), true, $this);
+
         $instance->setBar($this->get('bar'));
         $instance->initialize();
         sc_configure($instance);
@@ -49,6 +50,7 @@ class ProjectServiceContainer extends Container implements TaggedContainerInterf
     protected function getBarService()
     {
         $this->services['bar'] = $instance = new \FooClass('foo', $this->get('foo.baz'), $this->getParameter('foo_bar'));
+
         $this->get('foo.baz')->configure($instance);
 
         return $instance;
@@ -65,6 +67,7 @@ class ProjectServiceContainer extends Container implements TaggedContainerInterf
     protected function getFoo_BazService()
     {
         $this->services['foo.baz'] = $instance = call_user_func(array($this->getParameter('baz_class'), 'getInstance'));
+
         call_user_func(array($this->getParameter('baz_class'), 'configureStatic1'), $instance);
 
         return $instance;
@@ -97,10 +100,11 @@ class ProjectServiceContainer extends Container implements TaggedContainerInterf
         require_once '%path%foo.php';
 
         $this->services['method_call1'] = $instance = new \FooClass();
+
         $instance->setBar($this->get('foo'));
-        $instance->setBar($this->get('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE));
-        if ($this->has('foo')) {
-            $instance->setBar($this->get('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        $instance->setBar($this->get('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        if ($this->has('foo3')) {
+            $instance->setBar($this->get('foo3', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
         if ($this->has('foobaz')) {
             $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services_interfaces-1-1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services_interfaces-1-1.php
@@ -34,6 +34,7 @@ class ProjectServiceContainer extends Container implements TaggedContainerInterf
     protected function getFooService()
     {
         $this->services['foo'] = $instance = new \FooClass();
+
         $instance->setBar('someValue');
 
         return $instance;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services9.xml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services9.xml
@@ -43,10 +43,10 @@
         <argument type="service" id="foo" />
       </call>
       <call method="setBar">
-        <argument type="service" id="foo" on-invalid="null" />
+        <argument type="service" id="foo2" on-invalid="null" />
       </call>
       <call method="setBar">
-        <argument type="service" id="foo" on-invalid="ignore" />
+        <argument type="service" id="foo3" on-invalid="ignore" />
       </call>
       <call method="setBar">
         <argument type="service" id="foobaz" on-invalid="ignore" />

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services9.yml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services9.yml
@@ -32,8 +32,8 @@ services:
     file: %path%foo.php
     calls:
       - [setBar, ['@foo']]
-      - [setBar, ['@?foo']]
-      - [setBar, ['@?foo']]
+      - [setBar, ['@?foo2']]
+      - [setBar, ['@?foo3']]
       - [setBar, ['@?foobaz']]
       
   factory_service:


### PR DESCRIPTION
These optimizations reduced my container by about 50% (an overwhelming 3000 LOC less). A great example is the event dispatcher (see below). The dumper code is a bit ugly; a better tool for code generation would be nice, but I have no time to write one.

I made some changes to existing code to make it actually optimizable. In particular, I removed some runtime calls to `findTaggedServiceIds` and moved them to compiler passes.

```
/**
 * Gets the 'event_dispatcher' service.
 *
 * This service is shared.
 * This method always returns the same instance of the service.
 *
 * @return Symfony\Bundle\FrameworkBundle\Debug\EventDispatcher A Symfony\Bundle\FrameworkBundle\Debug\EventDispatcher instance.
 */
protected function getEventDispatcherService()
{
    $a = $this->get('zend.logger');
    $b = $this->get('security.access_map');
    $c = $this->get('security.context');
    $d = $this->get('security.authentication.provider.dao.security.matcher.mapf77ca6ff6a10951125548f77106c1a31.1');

    $e = new \Symfony\Component\HttpFoundation\RequestMatcher();
    $e->matchPath('/_profiler/.*');

    $f = new \Symfony\Component\HttpFoundation\RequestMatcher();
    $f->matchPath('/.*');

    $g = new \Symfony\Component\HttpKernel\Security\Firewall\LogoutListener($c, '/logout', '/');
    $g->addHandler(new \Symfony\Component\HttpKernel\Security\Logout\SessionLogoutHandler());

    $h = new \Symfony\Component\HttpKernel\Security\FirewallMap();
    $h->add($e, array(), NULL);
    $h->add($f, array(0 => new \Symfony\Component\HttpKernel\Security\Firewall\ChannelListener($b, new \Symfony\Component\HttpKernel\Security\EntryPoint\RetryAuthenticationEntryPoint(), $a), 1 => new \Symfony\Component\HttpKernel\Security\Firewall\ContextListener($c, array(0 => $this->get('security.authentication.provider.default')), $a), 2 => $g, 3 => new \Symfony\Component\HttpKernel\Security\Firewall\UsernamePasswordFormAuthenticationListener($c, $d, array('check_path' => '/login-check', 'login_path' => '/login', 'use_forward' => false, 'always_use_default_target_path' => false, 'default_target_path' => '/', 'target_path_parameter' => '_target_path', 'use_referer' => false, 'failure_path' => NULL, 'failure_forward' => false), $a), 4 => new \Symfony\Component\HttpKernel\Security\Firewall\AnonymousAuthenticationListener($c, 'SomeRandomValue', $a), 5 => new \Symfony\Component\HttpKernel\Security\Firewall\AccessListener($c, $this->get('security.access.decision_manager'), $b, new \Symfony\Component\Security\Authentication\AuthenticationProviderManager(array(0 => $d)), $a)), new \Symfony\Component\HttpKernel\Security\Firewall\ExceptionListener($c, $this->get('security.authentication.trust_resolver'), new \Symfony\Component\HttpKernel\Security\EntryPoint\FormAuthenticationEntryPoint('/login', false), NULL, $a));

    $this->services['event_dispatcher'] = $instance = new \Symfony\Bundle\FrameworkBundle\Debug\EventDispatcher($a);

    $instance->registerKernelListeners(array(128 => array(0 => new \Symfony\Component\HttpKernel\Security\Firewall($h), 1 => new \Symfony\Component\HttpKernel\Debug\ExceptionListener('Symfony\\Bundle\\FrameworkBundle\\Controller\\ExceptionController::exceptionAction', $a), 2 => new \Symfony\Bundle\WebProfilerBundle\WebDebugToolbarListener($this->get('controller_resolver'), true)), 0 => array(0 => new \Symfony\Bundle\FrameworkBundle\RequestListener($this, $this->get('router'), $a), 1 => new \Symfony\Component\HttpKernel\Cache\EsiListener(new \Symfony\Component\HttpKernel\Cache\Esi()), 2 => new \Symfony\Component\HttpKernel\ResponseListener(), 3 => new \Symfony\Component\HttpKernel\Profiler\ProfilerListener($this->get('profiler'), NULL, false))));

    return $instance;
}
```
