### PR TITLE
Acl fix possible duplicate security identities

### DIFF
--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -371,7 +371,10 @@ class AclProvider implements AclProviderInterface
                 if (!isset($loadedAces[$aceId])) {
                     if (!isset($sids[$key = ($username?'1':'0').$securityIdentifier])) {
                         if ($username) {
-                            $sids[$key] = new UserSecurityIdentity($securityIdentifier);
+                            $sids[$key] = new UserSecurityIdentity(
+                                substr($securityIdentifier, 1 + $pos = strpos($securityIdentifier, '-')),
+                                substr($securityIdentifier, 0, $pos)
+                            );
                         } else {
                             $sids[$key] = new RoleSecurityIdentity($securityIdentifier);
                         }

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -591,7 +591,7 @@ QUERY;
     protected function getInsertSecurityIdentitySql(SecurityIdentityInterface $sid)
     {
         if ($sid instanceof UserSecurityIdentity) {
-            $identifier = $sid->getUsername();
+            $identifier = $sid->getClass().'-'.$sid->getUsername();
             $username = true;
         } else if ($sid instanceof RoleSecurityIdentity) {
             $identifier = $sid->getRole();
@@ -659,7 +659,7 @@ QUERY;
     protected function getSelectSecurityIdentityIdSql(SecurityIdentityInterface $sid)
     {
         if ($sid instanceof UserSecurityIdentity) {
-            $identifier = $sid->getUsername();
+            $identifier = $sid->getClass().'-'.$sid->getUsername();
             $username = true;
         } else if ($sid instanceof RoleSecurityIdentity) {
             $identifier = $sid->getRole();

--- a/src/Symfony/Component/Security/Acl/Dbal/Schema.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/Schema.php
@@ -15,35 +15,35 @@ use Doctrine\DBAL\Schema\Schema as BaseSchema;
 
 /**
  * The schema used for the ACL system.
- * 
+ *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class Schema extends BaseSchema
 {
     protected $options;
-    
+
     /**
      * Constructor
-     * 
+     *
      * @param array $options the names for tables
      * @return void
      */
     public function __construct(array $options)
     {
         parent::__construct();
-        
+
         $this->options = $options;
-        
+
         $this->addClassTable();
         $this->addSecurityIdentitiesTable();
         $this->addObjectIdentitiesTable();
         $this->addObjectIdentityAncestorsTable();
         $this->addEntryTable();
     }
-    
+
     /**
      * Adds the class table to the schema
-     * 
+     *
      * @return void
      */
     protected function addClassTable()
@@ -54,16 +54,16 @@ class Schema extends BaseSchema
         $table->setPrimaryKey(array('id'));
         $table->addUniqueIndex(array('class_type'));
     }
-    
+
     /**
      * Adds the entry table to the schema
-     * 
+     *
      * @return void
      */
     protected function addEntryTable()
     {
         $table = $this->createTable($this->options['entry_table_name']);
-        
+
         $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
         $table->addColumn('class_id', 'integer', array('unsigned' => true));
         $table->addColumn('object_identity_id', 'integer', array('unsigned' => true, 'notnull' => false));
@@ -75,70 +75,70 @@ class Schema extends BaseSchema
         $table->addColumn('granting_strategy', 'string', array('length' => 30));
         $table->addColumn('audit_success', 'boolean', array('default' => 0));
         $table->addColumn('audit_failure', 'boolean', array('default' => 0));
-        
+
         $table->setPrimaryKey(array('id'));
         $table->addUniqueIndex(array('class_id', 'object_identity_id', 'field_name', 'ace_order'));
         $table->addIndex(array('class_id', 'object_identity_id', 'security_identity_id'));
-        
+
         $table->addForeignKeyConstraint($this->getTable($this->options['class_table_name']), array('class_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
         $table->addForeignKeyConstraint($this->getTable($this->options['oid_table_name']), array('object_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
         $table->addForeignKeyConstraint($this->getTable($this->options['sid_table_name']), array('security_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
     }
-    
+
     /**
      * Adds the object identity table to the schema
-     * 
+     *
      * @return void
      */
     protected function addObjectIdentitiesTable()
     {
         $table = $this->createTable($this->options['oid_table_name']);
-        
+
         $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
         $table->addColumn('class_id', 'integer', array('unsigned' => true));
         $table->addColumn('object_identifier', 'string', array('length' => 100));
         $table->addColumn('parent_object_identity_id', 'integer', array('unsigned' => true, 'notnull' => false));
         $table->addColumn('entries_inheriting', 'boolean', array('default' => 0));
-        
+
         $table->setPrimaryKey(array('id'));
         $table->addUniqueIndex(array('object_identifier', 'class_id'));
         $table->addIndex(array('parent_object_identity_id'));
-        
+
         $table->addForeignKeyConstraint($table, array('parent_object_identity_id'), array('id'), array('onDelete' => 'RESTRICT', 'onUpdate' => 'RESTRICT'));
     }
-    
+
     /**
      * Adds the object identity relation table to the schema
-     * 
+     *
      * @return void
      */
     protected function addObjectIdentityAncestorsTable()
     {
         $table = $this->createTable($this->options['oid_ancestors_table_name']);
-        
+
         $table->addColumn('object_identity_id', 'integer', array('unsigned' => true));
         $table->addColumn('ancestor_id', 'integer', array('unsigned' => true));
-        
+
         $table->setPrimaryKey(array('object_identity_id', 'ancestor_id'));
 
         $oidTable = $this->getTable($this->options['oid_table_name']);
         $table->addForeignKeyConstraint($oidTable, array('object_identity_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
         $table->addForeignKeyConstraint($oidTable, array('ancestor_id'), array('id'), array('onDelete' => 'CASCADE', 'onUpdate' => 'CASCADE'));
     }
-    
+
     /**
      * Adds the security identity table to the schema
-     * 
+     *
      * @return void
      */
     protected function addSecurityIdentitiesTable()
     {
         $table = $this->createTable($this->options['sid_table_name']);
-        
+
         $table->addColumn('id', 'integer', array('unsigned' => true, 'autoincrement' => 'auto'));
-        $table->addColumn('identifier', 'string', array('length' => 100));
+        $table->addColumn('identifier', 'string', array('length' => 200));
         $table->addColumn('username', 'boolean', array('default' => 0));
-        
+
         $table->setPrimaryKey(array('id'));
         $table->addUniqueIndex(array('identifier', 'username'));
     }

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -34,10 +34,10 @@ class ObjectIdentity implements ObjectIdentityInterface
      */
     public function __construct($identifier, $type)
     {
-        if (0 === strlen($identifier)) {
+        if (empty($identifier)) {
             throw new \InvalidArgumentException('$identifier cannot be empty.');
         }
-        if (0 === strlen($type)) {
+        if (empty($type)) {
             throw new \InvalidArgumentException('$type cannot be empty.');
         }
 

--- a/src/Symfony/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\Security\Acl\Domain;
 
+use Symfony\Component\Security\User\AccountInterface;
 use Symfony\Component\Security\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
 use Symfony\Component\Security\Authentication\AuthenticationTrustResolver;
@@ -46,9 +47,11 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
     public function getSecurityIdentities(TokenInterface $token)
     {
         $sids = array();
-        
-        if (false === $this->authenticationTrustResolver->isAnonymous($token)) {
-            $sids[] = new UserSecurityIdentity($token);
+
+        // add user security identity
+        $user = $token->getUser();
+        if ($user instanceof AccountInterface) {
+            $sids[] = UserSecurityIdentity::fromAccount($user);
         }
 
         // add all reachable roles

--- a/tests/Symfony/Tests/Component/Security/Acl/Dbal/MutableAclProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Dbal/MutableAclProviderTest.php
@@ -185,8 +185,8 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getProvider();
         $acl = $provider->createAcl(new ObjectIdentity(1, 'Foo'));
-        $ace = new Entry(1, $acl, new UserSecurityIdentity('foo'), 'all', 1, true, true, true);
-        $ace2 = new Entry(2, $acl, new UserSecurityIdentity('foo'), 'all', 1, true, true, true);
+        $ace = new Entry(1, $acl, new UserSecurityIdentity('foo', 'FooClass'), 'all', 1, true, true, true);
+        $ace2 = new Entry(2, $acl, new UserSecurityIdentity('foo', 'FooClass'), 'all', 1, true, true, true);
         $propertyChanges = $this->getField($provider, 'propertyChanges');
 
         $provider->propertyChanged($ace, 'mask', 1, 3);
@@ -286,7 +286,7 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getProvider();
         $acl = $provider->createAcl(new ObjectIdentity(1, 'Foo'));
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'FooClass');
         $acl->setEntriesInheriting(!$acl->isEntriesInheriting());
 
         $acl->insertObjectAce($sid, 1);

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/AclTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/AclTest.php
@@ -259,25 +259,25 @@ class AclTest extends \PHPUnit_Framework_TestCase
     {
         $acl = $this->getAcl();
 
-        $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('foo')));
-        $this->assertTrue($acl->isSidLoaded(new RoleSecurityIdentity('ROLE_FOO')));
+        $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('foo', 'Foo')));
+        $this->assertTrue($acl->isSidLoaded(new RoleSecurityIdentity('ROLE_FOO', 'Foo')));
     }
 
     public function testIsSidLoaded()
     {
-        $acl = new Acl(1, new ObjectIdentity('1', 'foo'), new PermissionGrantingStrategy(), array(new UserSecurityIdentity('foo'), new UserSecurityIdentity('johannes')), true);
+        $acl = new Acl(1, new ObjectIdentity('1', 'foo'), new PermissionGrantingStrategy(), array(new UserSecurityIdentity('foo', 'Foo'), new UserSecurityIdentity('johannes', 'Bar')), true);
 
-        $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('foo')));
-        $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('johannes')));
+        $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('foo', 'Foo')));
+        $this->assertTrue($acl->isSidLoaded(new UserSecurityIdentity('johannes', 'Bar')));
         $this->assertTrue($acl->isSidLoaded(array(
-            new UserSecurityIdentity('foo'),
-            new UserSecurityIdentity('johannes'),
+            new UserSecurityIdentity('foo', 'Foo'),
+            new UserSecurityIdentity('johannes', 'Bar'),
         )));
         $this->assertFalse($acl->isSidLoaded(new RoleSecurityIdentity('ROLE_FOO')));
-        $this->assertFalse($acl->isSidLoaded(new UserSecurityIdentity('schmittjoh@gmail.com')));
+        $this->assertFalse($acl->isSidLoaded(new UserSecurityIdentity('schmittjoh@gmail.com', 'Moo')));
         $this->assertFalse($acl->isSidLoaded(array(
-            new UserSecurityIdentity('foo'),
-            new UserSecurityIdentity('johannes'),
+            new UserSecurityIdentity('foo', 'Foo'),
+            new UserSecurityIdentity('johannes', 'Bar'),
             new RoleSecurityIdentity('ROLE_FOO'),
         )));
     }
@@ -343,7 +343,7 @@ class AclTest extends \PHPUnit_Framework_TestCase
     public function testUpdateFieldAce($type)
     {
         $acl = $this->getAcl();
-        $acl->{'insert'.$type}('foo', new UserSecurityIdentity('foo'), 1);
+        $acl->{'insert'.$type}('foo', new UserSecurityIdentity('foo', 'Foo'), 1);
 
         $listener = $this->getListener(array(
             'mask', 'mask', 'strategy'

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/DoctrineAclCacheTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/DoctrineAclCacheTest.php
@@ -60,7 +60,7 @@ class DoctrineAclCacheTest extends \PHPUnit_Framework_TestCase
         $acl = new Acl($id, new ObjectIdentity($id, 'foo'), $this->getPermissionGrantingStrategy(), array(), $depth > 0);
 
         // insert some ACEs
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
         $acl->insertClassAce($sid, 1);
         $acl->insertClassFieldAce('foo', $sid, 1);
         $acl->insertObjectAce($sid, 1);

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/PermissionGrantingStrategyTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/PermissionGrantingStrategyTest.php
@@ -30,7 +30,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new PermissionGrantingStrategy();
         $acl = $this->getAcl($strategy);
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
 
         $acl->insertClassAce($sid, 1);
         $acl->insertObjectAce($sid, 1, 0, false);
@@ -41,7 +41,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new PermissionGrantingStrategy();
         $acl = $this->getAcl($strategy);
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
 
         $acl->insertClassAce($sid, 1);
         $this->assertTrue($strategy->isGranted($acl, array(1), array($sid)));
@@ -50,7 +50,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     public function testIsGrantedFavorsLocalAcesOverParentAclAces()
     {
         $strategy = new PermissionGrantingStrategy();
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
 
         $acl = $this->getAcl($strategy);
         $acl->insertClassAce($sid, 1);
@@ -65,8 +65,8 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     public function testIsGrantedFallsBackToParentAcesIfNoLocalAcesAreApplicable()
     {
         $strategy = new PermissionGrantingStrategy();
-        $sid = new UserSecurityIdentity('johannes');
-        $anotherSid = new UserSecurityIdentity('ROLE_USER');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
+        $anotherSid = new UserSecurityIdentity('ROLE_USER', 'Foo');
 
         $acl = $this->getAcl($strategy);
         $acl->insertClassAce($anotherSid, 1, 0, false);
@@ -85,7 +85,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new PermissionGrantingStrategy();
         $acl = $this->getAcl($strategy);
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
 
         $strategy->isGranted($acl, array(1), array($sid));
     }
@@ -94,7 +94,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new PermissionGrantingStrategy();
         $acl = $this->getAcl($strategy);
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
         $aSid = new RoleSecurityIdentity('ROLE_USER');
 
         $acl->insertClassAce($aSid, 1);
@@ -111,7 +111,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new PermissionGrantingStrategy();
         $acl = $this->getAcl($strategy);
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
 
         $logger = $this->getMock('Symfony\Component\Security\Acl\Model\AuditLoggerInterface');
         $logger
@@ -130,7 +130,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new PermissionGrantingStrategy();
         $acl = $this->getAcl($strategy);
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
 
         $logger = $this->getMock('Symfony\Component\Security\Acl\Model\AuditLoggerInterface');
         $logger
@@ -152,7 +152,7 @@ class PermissionGrantingStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new PermissionGrantingStrategy();
         $acl = $this->getAcl($strategy);
-        $sid = new UserSecurityIdentity('johannes');
+        $sid = new UserSecurityIdentity('johannes', 'Foo');
 
         $acl->insertObjectAce($sid, $aceMask, 0, true, $maskStrategy);
 

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/RoleSecurityIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/RoleSecurityIdentityTest.php
@@ -13,17 +13,17 @@ class RoleSecurityIdentityTest extends \PHPUnit_Framework_TestCase
     public function testConstructor()
     {
         $id = new RoleSecurityIdentity('ROLE_FOO');
-        
+
         $this->assertEquals('ROLE_FOO', $id->getRole());
     }
-    
+
     public function testConstructorWithRoleInstance()
     {
         $id = new RoleSecurityIdentity(new Role('ROLE_FOO'));
-        
+
         $this->assertEquals('ROLE_FOO', $id->getRole());
     }
-    
+
     /**
      * @dataProvider getCompareData
      */
@@ -36,14 +36,14 @@ class RoleSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             $this->assertFalse($id1->equals($id2));
         }
     }
-    
+
     public function getCompareData()
     {
         return array(
             array(new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity('ROLE_FOO'), true),
             array(new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity(new Role('ROLE_FOO')), true),
             array(new RoleSecurityIdentity('ROLE_USER'), new RoleSecurityIdentity('ROLE_FOO'), false),
-            array(new RoleSecurityIdentity('ROLE_FOO'), new UserSecurityIdentity('ROLE_FOO'), false),
+            array(new RoleSecurityIdentity('ROLE_FOO'), new UserSecurityIdentity('ROLE_FOO', 'Foo'), false),
         );
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategyTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategyTest.php
@@ -13,22 +13,20 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getSecurityIdentityRetrievalTests
      */
-    public function testGetSecurityIdentities($username, array $roles, $authenticationStatus, array $sids)
+    public function testGetSecurityIdentities($user, array $roles, $authenticationStatus, array $sids)
     {
         $strategy = $this->getStrategy($roles, $authenticationStatus);
-        $token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface');
 
-        if ('anonymous' !== $authenticationStatus) {
-            $token
-                ->expects($this->once())
-                ->method('__toString')
-                ->will($this->returnValue($username))
-            ;
-        }
+        $token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface');
         $token
             ->expects($this->once())
             ->method('getRoles')
             ->will($this->returnValue(array('foo')))
+        ;
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->will($this->returnValue($user))
         ;
 
         $extractedSids = $strategy->getSecurityIdentities($token);
@@ -47,16 +45,16 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit_Framework_TestCase
     public function getSecurityIdentityRetrievalTests()
     {
         return array(
-            array('johannes', array('ROLE_USER', 'ROLE_SUPERADMIN'), 'fullFledged', array(
-                new UserSecurityIdentity('johannes'),
+            array($this->getAccount('johannes', 'FooUser'), array('ROLE_USER', 'ROLE_SUPERADMIN'), 'fullFledged', array(
+                new UserSecurityIdentity('johannes', 'FooUser'),
                 new RoleSecurityIdentity('ROLE_USER'),
                 new RoleSecurityIdentity('ROLE_SUPERADMIN'),
                 new RoleSecurityIdentity('IS_AUTHENTICATED_FULLY'),
                 new RoleSecurityIdentity('IS_AUTHENTICATED_REMEMBERED'),
                 new RoleSecurityIdentity('IS_AUTHENTICATED_ANONYMOUSLY'),
             )),
-            array('foo', array('ROLE_FOO'), 'rememberMe', array(
-                new UserSecurityIdentity('foo'),
+            array($this->getAccount('foo', 'FooBarUser'), array('ROLE_FOO'), 'rememberMe', array(
+                new UserSecurityIdentity('foo', 'FooBarUser'),
                 new RoleSecurityIdentity('ROLE_FOO'),
                 new RoleSecurityIdentity('IS_AUTHENTICATED_REMEMBERED'),
                 new RoleSecurityIdentity('IS_AUTHENTICATED_ANONYMOUSLY'),
@@ -66,6 +64,18 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit_Framework_TestCase
                 new RoleSecurityIdentity('IS_AUTHENTICATED_ANONYMOUSLY'),
             ))
         );
+    }
+
+    protected function getAccount($username, $class)
+    {
+        $account = $this->getMock('Symfony\Component\Security\User\AccountInterface', array(), array(), $class);
+        $account
+            ->expects($this->once())
+            ->method('__toString')
+            ->will($this->returnValue($username))
+        ;
+
+        return $account;
     }
 
     protected function getStrategy(array $roles = array(), $authenticationStatus = 'fullFledged')
@@ -124,7 +134,7 @@ class SecurityIdentityRetrievalStrategyTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue(false))
             ;
         }
-        
+
 
         return new SecurityIdentityRetrievalStrategy($roleHierarchy, $trustResolver);
     }

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
@@ -10,25 +10,12 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
     {
-        $id = new UserSecurityIdentity('foo');
-        
+        $id = new UserSecurityIdentity('foo', 'Foo');
+
         $this->assertEquals('foo', $id->getUsername());
+        $this->assertEquals('Foo', $id->getClass());
     }
-    
-    public function testConstructorWithToken()
-    {
-        $token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface');
-        $token
-            ->expects($this->once())
-            ->method('__toString')
-            ->will($this->returnValue('foo'))
-        ;
-        
-        $id = new UserSecurityIdentity($token);
-        
-        $this->assertEquals('foo', $id->getUsername());
-    }
-    
+
     /**
      * @dataProvider getCompareData
      */
@@ -41,21 +28,23 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             $this->assertFalse($id1->equals($id2));
         }
     }
-    
+
     public function getCompareData()
     {
-        $token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface');
-        $token
+        $account = $this->getMock('Symfony\Component\Security\User\AccountInterface');
+        $account
             ->expects($this->once())
             ->method('__toString')
             ->will($this->returnValue('foo'))
         ;
-        
+
         return array(
-            array(new UserSecurityIdentity('foo'), new UserSecurityIdentity('foo'), true),
-            array(new UserSecurityIdentity('foo'), new UserSecurityIdentity($token), true),
-            array(new UserSecurityIdentity('bla'), new UserSecurityIdentity('blub'), false),
-            array(new UserSecurityIdentity('foo'), new RoleSecurityIdentity('foo'), false),
+            array(new UserSecurityIdentity('foo', 'Foo'), new UserSecurityIdentity('foo', 'Foo'), true),
+            array(new UserSecurityIdentity('foo', 'Bar'), new UserSecurityIdentity('foo', 'Foo'), false),
+            array(new UserSecurityIdentity('foo', 'Foo'), new UserSecurityIdentity('bar', 'Foo'), false),
+            array(new UserSecurityIdentity('foo', 'Foo'), UserSecurityIdentity::fromAccount($account), false),
+            array(new UserSecurityIdentity('bla', 'Foo'), new UserSecurityIdentity('blub', 'Foo'), false),
+            array(new UserSecurityIdentity('foo', 'Foo'), new RoleSecurityIdentity('foo'), false),
         );
     }
 }


### PR DESCRIPTION
The ACL was still assuming the username to be unique, this commit changes this to user class + username.
