### PR TITLE
Twig compiler

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Node/FormThemeNode.php
+++ b/src/Symfony/Bundle/TwigBundle/Node/FormThemeNode.php
@@ -28,7 +28,7 @@ class FormThemeNode extends \Twig_Node
      *
      * @param \Twig_Compiler A Twig_Compiler instance
      */
-    public function compile($compiler)
+    public function compile(\Twig_Compiler $compiler)
     {
         $compiler
             ->addDebugInfo($this)

--- a/src/Symfony/Bundle/TwigBundle/Node/HelperNode.php
+++ b/src/Symfony/Bundle/TwigBundle/Node/HelperNode.php
@@ -28,7 +28,7 @@ class HelperNode extends \Twig_Node
      *
      * @param \Twig_Compiler A Twig_Compiler instance
      */
-    public function compile($compiler)
+    public function compile(\Twig_Compiler $compiler)
     {
         $compiler
             ->addDebugInfo($this)

--- a/src/Symfony/Bundle/TwigBundle/Node/IncludeNode.php
+++ b/src/Symfony/Bundle/TwigBundle/Node/IncludeNode.php
@@ -28,7 +28,7 @@ class IncludeNode extends \Twig_Node
      *
      * @param \Twig_Compiler A Twig_Compiler instance
      */
-    public function compile($compiler)
+    public function compile(\Twig_Compiler $compiler)
     {
         // template
         $compiler

--- a/src/Symfony/Bundle/TwigBundle/Node/TransNode.php
+++ b/src/Symfony/Bundle/TwigBundle/Node/TransNode.php
@@ -28,7 +28,7 @@ class TransNode extends \Twig_Node
      *
      * @param \Twig_Compiler A Twig_Compiler instance
      */
-    public function compile($compiler)
+    public function compile(\Twig_Compiler $compiler)
     {
         $compiler->addDebugInfo($this);
 


### PR DESCRIPTION
this commit fixes the exception due to missing type hintings when overriding the `compile()` method
