### PR TITLE
Fix assertType deprecation warning

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -120,7 +120,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $definition = $container->getDefinition('doctrine.odm.mongodb.default_configuration');
         $methodCalls = $definition->getMethodCalls();
         $methodNames = array_map(function($call) { return $call[0]; }, $methodCalls);
-        $this->assertType('integer', $pos = array_search('setDefaultDB', $methodNames));
+        $this->assertInternalType('integer', $pos = array_search('setDefaultDB', $methodNames));
         $this->assertEquals('mydb', $methodCalls[$pos][1][0]);
 
         $definition = $container->getDefinition('doctrine.odm.mongodb.default_document_manager');

--- a/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
@@ -95,7 +95,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($builder->get('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE), '->get() returns null if the service does not exist and NULL_ON_INVALID_REFERENCE is passed as a second argument');
 
         $builder->register('foo', 'stdClass');
-        $this->assertType('object', $builder->get('foo'), '->get() returns the service definition associated with the id');
+        $this->assertInternalType('object', $builder->get('foo'), '->get() returns the service definition associated with the id');
         $builder->set('bar', $bar = new \stdClass());
         $this->assertEquals($bar, $builder->get('bar'), '->get() returns the service associated with the id');
         $builder->register('bar', 'stdClass');
@@ -243,7 +243,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder->register('baz_service')->setFactoryService('baz_factory')->setFactoryMethod('getInstance');
         $builder->register('baz_factory', 'BazClass');
 
-        $this->assertType('BazClass', $builder->get('baz_service'));
+        $this->assertInstanceOf('BazClass', $builder->get('baz_service'));
     }
 
     /**

--- a/tests/Symfony/Tests/Component/DomCrawler/CrawlerTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/CrawlerTest.php
@@ -313,7 +313,7 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
     public function testLinks()
     {
         $crawler = $this->createTestCrawler()->selectLink('Foo');
-        $this->assertType('array', $crawler->links(), '->links() returns an array');
+        $this->assertInternalType('array', $crawler->links(), '->links() returns an array');
 
         $this->assertEquals(4, count($crawler->links()), '->links() returns an array');
         $links = $crawler->links();

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -490,7 +490,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $req = new Request;
         $retval = $req->getContent(true);
-        $this->assertType('resource', $retval);
+        $this->assertInternalType('resource', $retval);
         $this->assertEquals("", fread($retval, 1));
         $this->assertTrue(feof($retval));
     }


### PR DESCRIPTION
PHPUnit 3.6 replaces assertType with assertInternalType and assertInstanceOf.
