### PR TITLE
Mongo mapping

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -149,8 +149,14 @@ class DoctrineMongoDBExtension extends Extension
         $proxyCacheDir = $container->getParameter('kernel.cache_dir').'/doctrine/odm/mongodb/Proxies';
         $hydratorCacheDir = $container->getParameter('kernel.cache_dir').'/doctrine/odm/mongodb/Hydrators';
 
-        $odmConfigDef = new Definition('%doctrine.odm.mongodb.configuration_class%');
-        $container->setDefinition(sprintf('doctrine.odm.mongodb.%s_configuration', $documentManager['name']), $odmConfigDef);
+        $configServiceName = sprintf('doctrine.odm.mongodb.%s_configuration', $documentManager['name']);
+
+		if ($container->hasDefinition($configServiceName)) {
+			$odmConfigDef = $container->getDefinition($configServiceName);
+		} else {
+			$odmConfigDef = new Definition('%doctrine.odm.mongodb.configuration_class%');
+			$container->setDefinition($configServiceName, $odmConfigDef);
+		}
 
         $this->loadDocumentManagerBundlesMappingInformation($documentManager, $odmConfigDef, $container);
         $this->loadDocumentManagerMetadataCacheDriver($documentManager, $container);
@@ -362,7 +368,17 @@ class DoctrineMongoDBExtension extends Extension
 
         $this->loadMappingInformation($documentManager, $container);
         $this->registerMappingDrivers($documentManager, $container);
-        
+
+		if ($odmConfigDef->hasMethodCall('setDocumentNamespaces')) {
+            // TODO: Can we make a method out of it on Definition? replaceMethodArguments() or something.
+            $calls = $odmConfigDef->getMethodCalls();
+            foreach ($calls AS $call) {
+                if ($call[0] == 'setDocumentNamespaces') {
+                    $this->aliasMap = array_merge($call[1][0], $this->aliasMap);
+                }
+            }
+            $method = $odmConfigDef->removeMethodCall('setDocumentNamespaces');
+        }
         $odmConfigDef->addMethodCall('setDocumentNamespaces', array($this->aliasMap));
     }
 


### PR DESCRIPTION
Fixes the mongo mapping being overwritten if additional configurations are set in subsequent configs.  ie mapping in config.yml being overwritten by addition mongo config (like default_db) in config_dev.yml

Code lifted from DoctrineBundle
