### PR TITLE
Intercept redirect: more details for intercepted response

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
@@ -53,7 +53,7 @@ class WebDebugToolbarListener
 
         if ($response->headers->has('X-Debug-Token') && $response->isRedirect() && $this->interceptRedirects) {
             $response->setContent(
-                sprintf('<html><head></head><body><h1>This Request redirects to<br /><a href="%s">%s</a>.</h1></body></html>',
+                sprintf('<html><head></head><body><h1>This Request redirects to<br /><a href="%s">%s</a>.</h1><h4>The redirect was intercepted by the web debug toolbar to help debugging.<br/>For more information, see the "intercept-redirects" option of the Profiler.</h4></body></html>',
                 $response->headers->get('location'), $response->headers->get('location'))
             );
             $response->setStatusCode(200);


### PR DESCRIPTION
Hey Fabien-

As the commit says, this just gives a little bit more information as to "why" a request was intercepted and some general direction on how to find out more. Judging by your code, I don't _think_ you're too crazy about embedding this type of documentation into the code, but we did just have a question about this on the board.

Thanks!
