### PR TITLE
Create aliases for security providers that are explicit services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
@@ -363,7 +363,9 @@ class SecurityExtension extends Extension
 
         // Existing DAO service provider
         if (isset($provider['id'])) {
-            return array($provider['id'], $encoder);
+            $container->setAlias($name, $provider['id']);
+
+            return array($name, $encoder);
         }
 
         // Chain provider

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/provider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/provider.php
@@ -17,5 +17,8 @@ $container->loadFromExtension('security', 'config', array(
         'doctrine' => array(
             'entity' => array('class' => 'SecurityBundle:User', 'property' => 'username')
         ),
+        'service' => array(
+            'id' => 'user.manager',
+        ),
     )
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/provider.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/provider.xml
@@ -19,5 +19,7 @@
         <provider name="doctrine">
             <entity class="SecurityBundle:User" property="username" />
         </provider>
+
+        <provider name="service" id="user.manager" />
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/provider.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/provider.yml
@@ -12,3 +12,6 @@ security.config:
 
         doctrine:
             entity: { class: SecurityBundle:User, property: username }
+
+        service:
+            id: user.manager

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -33,7 +33,7 @@ abstract class SecurityExtensionTest extends TestCase
     {
         $container = $this->getContainer('provider');
 
-        $providers = array_values(array_filter(array_keys($container->getDefinitions()), function ($key) { return 0 === strpos($key, 'security.authentication.provider.'); }));
+        $providers = array_values(array_filter($container->getServiceIds(), function ($key) { return 0 === strpos($key, 'security.authentication.provider.'); }));
 
         $this->assertEquals(array(
             'security.authentication.provider.digest',
@@ -42,6 +42,7 @@ abstract class SecurityExtensionTest extends TestCase
             'security.authentication.provider.basic_b7f0cf21802ffc8b22cadbb255f07213',
             'security.authentication.provider.basic_98e44377704554700e68c22094b51ca4',
             'security.authentication.provider.doctrine',
+            'security.authentication.provider.service',
         ), $providers);
     }
 


### PR DESCRIPTION
I noticed that when using FOS/UserBundle (formerly DoctrineUserBundle) and the configuration:

```
security.config:
    providers:
        fos_user: { id: fos_user.user_manager }
    firewalls:
        public:
            form_login: { provider: fos_user }
```

The FormLoginFactory class would choke when trying to resolve `$providerIds[$userProvider]`.  Providers that were linked to explicit services (using "id") were not consistent with the provider services created on-demand by SecurityExtension (e.g. in-memory or Doctrine).  A quick solution is to create an alias for the naming convention, using the provider key ("fos_user" in the above example).

I spoke with Johannes about aliases affecting the public/private optimization for the DIC, but we reasoned this was a justified use of aliases.
