### PR TITLE
Services' visibility changes

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -112,11 +112,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
         } else {
             $containerClass = isset($connection['configuration-class']) ? $connection['configuration-class'] : (isset($connection['configuration_class']) ? $connection['configuration_class'] : 'Doctrine\DBAL\Configuration');
             $containerDef = new Definition($containerClass);
+            $containerDef->setPublic(false);
             $containerDef->addMethodCall('setSqlLogger', array(new Reference('doctrine.dbal.logger')));
             $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $connection['name']), $containerDef);
 
             $driverOptions = array();
             $driverDef = new Definition('Doctrine\DBAL\DriverManager');
+            $driverDef->setPublic(false);
             $driverDef->setFactoryMethod('getConnection');
             $container->setDefinition(sprintf('doctrine.dbal.%s_connection', $connection['name']), $driverDef);
         }
@@ -304,6 +306,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $ormConfigDef = $container->getDefinition($configServiceName);
         } else {
             $ormConfigDef = new Definition('Doctrine\ORM\Configuration');
+            $ormConfigDef->setPublic(false);
             $container->setDefinition($configServiceName, $ormConfigDef);
         }
 
@@ -534,6 +537,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         if ('memcache' === $type) {
             $memcacheClass = isset($cacheDriver['class']) ? $cacheDriver['class'] : '%'.sprintf('doctrine.orm.cache.%s_class', $type).'%';
             $cacheDef = new Definition($memcacheClass);
+            $cacheDef->setPublic(false);
             $memcacheHost = is_array($cacheDriver) && isset($cacheDriver['host']) ? $cacheDriver['host'] : '%doctrine.orm.cache.memcache_host%';
             $memcachePort = is_array($cacheDriver) && isset($cacheDriver['port']) ? $cacheDriver['port'] : '%doctrine.orm.cache.memcache_port%';
             $memcacheInstanceClass = is_array($cacheDriver) && isset($cacheDriver['instance-class']) ? $cacheDriver['instance-class'] : (is_array($cacheDriver) && isset($cacheDriver['instance_class']) ? $cacheDriver['instance_class'] : '%doctrine.orm.cache.memcache_instance_class%');
@@ -543,6 +547,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $cacheDef->addMethodCall('setMemcache', array(new Reference(sprintf('doctrine.orm.%s_memcache_instance', $entityManager['name']))));
         } else {
             $cacheDef = new Definition('%'.sprintf('doctrine.orm.cache.%s_class', $type).'%');
+            $cacheDef->setPublic(false);
         }
         return $cacheDef;
     }

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
@@ -15,9 +15,9 @@
     </parameters>
 
     <services>
-        <service id="doctrine.dbal.logger.debug" class="%doctrine.dbal.logger.debug_class%" />
+        <service id="doctrine.dbal.logger.debug" class="%doctrine.dbal.logger.debug_class%" public="false" />
 
-        <service id="doctrine.dbal.logger" class="%doctrine.dbal.logger_class%">
+        <service id="doctrine.dbal.logger" class="%doctrine.dbal.logger_class%" public="false">
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -46,7 +46,7 @@
 
     <services>
         <!--- Annotation Metadata Reader Service -->
-        <service id="doctrine.orm.metadata.annotation_reader" class="%doctrine.orm.metadata.annotation_reader_class%">
+        <service id="doctrine.orm.metadata.annotation_reader" class="%doctrine.orm.metadata.annotation_reader_class%" public="false">
             <call method="setAnnotationNamespaceAlias">
               <argument>Doctrine\ORM\Mapping\</argument>
               <argument>orm</argument>
@@ -55,7 +55,7 @@
 
         <service id="security.user.entity_manager" alias="doctrine.orm.default_entity_manager" />
 
-        <service id="request.param_converter.doctrine" class="Symfony\Bundle\DoctrineBundle\Request\ParamConverter\DoctrineConverter">
+        <service id="request.param_converter.doctrine" class="Symfony\Bundle\DoctrineBundle\Request\ParamConverter\DoctrineConverter" public="false">
             <tag name="request.param_converter" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -432,6 +432,7 @@ class FrameworkExtension extends Extension
                     $container->setAlias('profiler.request_matcher', (string) $config['profiler']['matcher']['_services'][0]);
                 } else {
                     $definition = $container->register('profiler.request_matcher', 'Symfony\\Component\\HttpFoundation\\RequestMatcher');
+                    $definition->setPublic(false);
 
                     if (isset($config['profiler']['matcher']['ip'])) {
                         $definition->addMethodCall('matchIp', array($config['profiler']['matcher']['ip']));
@@ -482,11 +483,13 @@ class FrameworkExtension extends Extension
                 $container->getParameter('validator.mapping.loader.xml_files_loader.class'),
                 array($xmlMappingFiles)
             );
+            $xmlFilesLoader->setPublic(false);
 
             $yamlFilesLoader = new Definition(
                 $container->getParameter('validator.mapping.loader.yaml_files_loader.class'),
                 array($yamlMappingFiles)
             );
+            $yamlFilesLoader->setPublic(false);
 
             $container->setDefinition('validator.mapping.loader.xml_files_loader', $xmlFilesLoader);
             $container->setDefinition('validator.mapping.loader.yaml_files_loader', $yamlFilesLoader);
@@ -508,8 +511,9 @@ class FrameworkExtension extends Extension
                 }
 
                 $annotationLoader = new Definition($container->getParameter('validator.mapping.loader.annotation_loader.class'));
+                $annotationLoader->setPublic(false);
                 $annotationLoader->addArgument(new Parameter('validator.annotations.namespaces'));
-                
+
                 $container->setDefinition('validator.mapping.loader.annotation_loader', $annotationLoader);
 
                 $loader = $container->getDefinition('validator.mapping.loader.loader_chain');

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -26,7 +26,8 @@ class FormLoginFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->register($provider, '%security.authentication.provider.dao.class%')
-            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder.'.$providerIds[$userProvider])));
+            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder.'.$providerIds[$userProvider])))
+            ->setPublic(false)
         ;
 
         // listener

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -26,7 +26,8 @@ class HttpBasicFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->register($provider, '%security.authentication.provider.dao.class%')
-            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder.'.$providerIds[$userProvider])));
+            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder.'.$providerIds[$userProvider])))
+            ->setPublic(false)
         ;
 
         // listener

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -26,7 +26,8 @@ class HttpDigestFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->register($provider, '%security.authentication.provider.dao.class%')
-            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder.'.$providerIds[$userProvider])));
+            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder.'.$providerIds[$userProvider])))
+            ->setPublic(false)
         ;
 
         // listener

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/X509Factory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/X509Factory.php
@@ -27,6 +27,7 @@ class X509Factory implements SecurityFactoryInterface
         $container
             ->register($provider, '%security.authentication.provider.pre_authenticated.class%')
             ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker')))
+            ->setPublic(false)
         ;
 
         // listener

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
@@ -109,6 +109,7 @@ class SecurityExtension extends Extension
             // matcher
             $id = 'security.matcher.url.'.$i;
             $definition = $container->register($id, '%security.matcher.class%');
+            $definition->setPublic(false);
             if (isset($access['path'])) {
                 $definition->addMethodCall('matchPath', array(is_array($access['path']) ? $access['path']['pattern'] : $access['path']));
             }
@@ -179,6 +180,7 @@ class SecurityExtension extends Extension
             $id = 'security.matcher.map'.$id.'.'.++$i;
             $matcher = $container
                 ->register($id, '%security.matcher.class%')
+                ->setPublic(false)
                 ->addMethodCall('matchPath', array($firewall['pattern']))
             ;
             $matcher = new Reference($id);
@@ -378,6 +380,7 @@ class SecurityExtension extends Extension
         if (isset($provider['entity'])) {
             $container
                 ->register($name, '%security.user.provider.entity.class%')
+                ->setPublic(false)
                 ->setArguments(array(
                     new Reference('security.user.entity_manager'),
                     $provider['entity']['class'],
@@ -391,6 +394,7 @@ class SecurityExtension extends Extension
         if (isset($provider['document'])) {
             $container
                 ->register($name, '%security.user.provider.document.class%')
+                ->setPublic(false)
                 ->setArguments(array(
                     new Reference('security.user.document_manager'),
                     $provider['document']['class'],
@@ -402,6 +406,7 @@ class SecurityExtension extends Extension
 
         // In-memory DAO provider
         $definition = $container->register($name, '%security.user.provider.in_memory.class%');
+        $definition->setPublic(false);
         foreach ($this->fixConfig($provider, 'user') as $username => $user) {
             if (isset($user['name'])) {
                 $username = $user['name'];
@@ -427,6 +432,7 @@ class SecurityExtension extends Extension
             $container
                 ->register($userId, 'Symfony\Component\Security\User\User')
                 ->setArguments(array($username, $user['password'], $user['roles']))
+                ->setPublic(false)
             ;
 
             $definition->addMethodCall('createUser', array(new Reference($userId)));
@@ -447,6 +453,7 @@ class SecurityExtension extends Extension
         $container
             ->register($authManager, '%security.authentication.manager.class%')
             ->addArgument($providers)
+            ->setPublic(false)
         ;
 
         // Access listener

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/param_converter.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/param_converter.xml
@@ -11,10 +11,10 @@
 
     <services>
         <!-- ConverterManager -->
-        <service id="request.param_converter.manager" class="%request.param_converter.manager.class%" />
+        <service id="request.param_converter.manager" class="%request.param_converter.manager.class%" public="false" />
 
         <!-- ParamConverterListener -->
-        <service id="request.param_converter.listener" class="%request.param_converter.listener.class%">
+        <service id="request.param_converter.listener" class="%request.param_converter.listener.class%" public="false">
             <tag name="kernel.listener" />
             <argument type="service" id="request.param_converter.manager" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -19,12 +19,12 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="profiler.storage" class="%profiler.storage.class%">
+        <service id="profiler.storage" class="%profiler.storage.class%" public="false">
             <argument>%profiler.storage.file%</argument>
             <argument>%profiler.storage.lifetime%</argument>
         </service>
 
-        <service id="profiler_listener" class="%profiler_listener.class%">
+        <service id="profiler_listener" class="%profiler_listener.class%" public="false">
             <tag name="kernel.listener" />
             <argument type="service" id="profiler" />
             <argument type="service" id="profiler.request_matcher" on-invalid="null" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -20,19 +20,19 @@
     </parameters>
 
     <services>
-        <service id="routing.resolver" class="%routing.resolver.class%" />
+        <service id="routing.resolver" class="%routing.resolver.class%" public="false" />
 
-        <service id="routing.loader.xml" class="%routing.loader.xml.class%">
+        <service id="routing.loader.xml" class="%routing.loader.xml.class%" public="false">
             <tag name="routing.loader" />
             <argument>%kernel.bundle_dirs%</argument>
         </service>
 
-        <service id="routing.loader.yml" class="%routing.loader.yml.class%">
+        <service id="routing.loader.yml" class="%routing.loader.yml.class%" public="false">
             <tag name="routing.loader" />
             <argument>%kernel.bundle_dirs%</argument>
         </service>
 
-        <service id="routing.loader.php" class="%routing.loader.php.class%">
+        <service id="routing.loader.php" class="%routing.loader.php.class%" public="false">
             <tag name="routing.loader" />
             <argument>%kernel.bundle_dirs%</argument>
         </service>
@@ -43,7 +43,7 @@
             <argument type="service" id="routing.resolver" />
         </service>
 
-        <service id="routing.loader" class="Symfony\Bundle\FrameworkBundle\Routing\LazyLoader">
+        <service id="routing.loader" class="Symfony\Bundle\FrameworkBundle\Routing\LazyLoader" public="false">
             <argument type="service" id="service_container" />
             <argument>routing.loader.real</argument>
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -91,15 +91,15 @@
 
         <service id="security.account_checker" class="%security.account_checker.class%" public="false" />
 
-        <service id="security.encoder.sha1" class="%security.encoder.digest.class%">
+        <service id="security.encoder.sha1" class="%security.encoder.digest.class%" public="false">
             <argument>sha1</argument>
         </service>
 
-        <service id="security.encoder.md5" class="%security.encoder.digest.class%">
+        <service id="security.encoder.md5" class="%security.encoder.digest.class%" public="false">
             <argument>md5</argument>
         </service>
 
-        <service id="security.encoder.plain" class="%security.encoder.plain.class%" />
+        <service id="security.encoder.plain" class="%security.encoder.plain.class%" public="false" />
 
         <service id="security.logout.handler.session" class="%security.logout.handler.session.class%" public="false"></service>
 
@@ -155,7 +155,7 @@
             <argument type="service" id="security.role_hierarchy" />
         </service>
 
-        <service id="security.firewall" class="%security.firewall.class%">
+        <service id="security.firewall" class="%security.firewall.class%" public="false">
             <tag name="kernel.listener" priority="128" />
             <argument type="service" id="security.firewall.map" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_acl.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_acl.xml
@@ -28,14 +28,14 @@
     <services>
         <service id="security.acl.dbal.connection" alias="doctrine.dbal.default_connection" />
     
-        <service id="security.acl.object_identity_retrieval_strategy" class="%security.acl.object_identity_retrieval_strategy.class%"></service>
+        <service id="security.acl.object_identity_retrieval_strategy" class="%security.acl.object_identity_retrieval_strategy.class%" public="false"></service>
         
-        <service id="security.acl.security_identity_retrieval_strategy" class="%security.acl.security_identity_retrieval_strategy.class%">
+        <service id="security.acl.security_identity_retrieval_strategy" class="%security.acl.security_identity_retrieval_strategy.class%" public="false">
             <argument type="service" id="security.role_hierarchy" />
             <argument type="service" id="security.authentication.trust_resolver" />
         </service>
     
-        <service id="security.acl.dbal.provider" class="%security.acl.dbal.provider.class%">
+        <service id="security.acl.dbal.provider" class="%security.acl.dbal.provider.class%" public="false">
             <argument type="service" id="security.acl.dbal.connection" />
             <argument type="service" id="security.acl.permission_granting_strategy" />
             <argument type="collection">
@@ -50,13 +50,13 @@
 
         <service id="security.acl.provider" alias="security.acl.dbal.provider" />
         
-        <service id="security.acl.permission_granting_strategy" class="%security.acl.permission_granting_strategy.class%">
+        <service id="security.acl.permission_granting_strategy" class="%security.acl.permission_granting_strategy.class%" public="false">
             <call method="setAuditLogger">
                 <argument type="service" id="security.acl.audit_logger" on-invalid="ignore" />
             </call>
         </service>
         
-        <service id="security.acl.cache.doctrine" class="%security.acl.cache.doctrine.class%">
+        <service id="security.acl.cache.doctrine" class="%security.acl.cache.doctrine.class%" public="false">
             <argument type="service" id="security.acl.cache.doctrine_cache_impl" />
             <argument type="service" id="security.acl.permission_granting_strategy" />        
             <argument>%security.acl.cache.doctrine.prefix%</argument>
@@ -64,9 +64,9 @@
         
         <service id="security.acl.cache.doctrine.cache_impl" alias="doctrine.orm.default_result_cache" />
         
-        <service id="security.acl.permission.map" class="%security.acl.permission.map.class%"></service>
+        <service id="security.acl.permission.map" class="%security.acl.permission.map.class%" public="false"></service>
         
-        <service id="security.acl.voter.basic_permissions" class="%security.acl.voter.class%">
+        <service id="security.acl.voter.basic_permissions" class="%security.acl.voter.class%" public="false">
             <argument type="service" id="security.acl.provider" />
             <argument type="service" id="security.acl.object_identity_retrieval_strategy" />
             <argument type="service" id="security.acl.security_identity_retrieval_strategy" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
@@ -21,24 +21,24 @@
             <tag name="security.listener.factory" />
         </service>
         
-        <service id="security.logout_listener" class="%security.logout_listener.class%">
+        <service id="security.logout_listener" class="%security.logout_listener.class%" public="false">
             <argument type="service" id="security.context" />
             <argument>%security.logout.path%</argument>
             <argument>%security.logout.target_path%</argument>
         </service>
         
-        <service id="security.logout.handler.cookie_clearing" class="%security.logout.handler.cookie_clearing.class%">
+        <service id="security.logout.handler.cookie_clearing" class="%security.logout.handler.cookie_clearing.class%" public="false">
             <argument type="collection"></argument>
         </service>        
 
-        <service id="security.authentication.listener.form" class="%security.authentication.listener.form.class%">
+        <service id="security.authentication.listener.form" class="%security.authentication.listener.form.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
             <argument>%security.authentication.form.options%</argument>
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.listener.x509" class="%security.authentication.listener.x509.class%">
+        <service id="security.authentication.listener.x509" class="%security.authentication.listener.x509.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
             <argument>%security.authentication.x509.user%</argument>
@@ -46,21 +46,21 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.listener.basic" class="%security.authentication.listener.basic.class%">
+        <service id="security.authentication.listener.basic" class="%security.authentication.listener.basic.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.authentication.basic_entry_point" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.listener.digest" class="%security.authentication.listener.digest.class%">
+        <service id="security.authentication.listener.digest" class="%security.authentication.listener.digest.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.user.provider.in_memory" />
             <argument type="service" id="security.authentication.digest_entry_point" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.exception_listener" class="%security.exception_listener.class%">
+        <service id="security.exception_listener" class="%security.exception_listener.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.trust_resolver" />
             <argument type="service" id="security.authentication.entry_point" on-invalid="null" />
@@ -68,7 +68,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.switchuser_listener" class="%security.authentication.switchuser_listener.class%">
+        <service id="security.authentication.switchuser_listener" class="%security.authentication.switchuser_listener.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.user.provider.in_memory" />
             <argument type="service" id="security.account_checker" />
@@ -78,7 +78,7 @@
             <argument>%security.authentication.switchuser.role%</argument>
         </service>
 
-        <service id="security.access_listener" class="%security.access_listener.class%">
+        <service id="security.access_listener" class="%security.access_listener.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="security.access_map" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -23,16 +23,16 @@
             </argument>
         </service>
 
-        <service id="session.storage.native" class="%session.storage.native.class%">
+        <service id="session.storage.native" class="%session.storage.native.class%" public="false">
             <argument>%session.storage.native.options%</argument>
         </service>
 
-        <service id="session.storage.pdo" class="%session.storage.pdo.class%">
+        <service id="session.storage.pdo" class="%session.storage.pdo.class%" public="false">
             <argument type="service" id="pdo_connection" />
             <argument>%session.storage.pdo.options%</argument>
         </service>
 
-        <service id="session.storage.array" class="%session.storage.array.class%">
+        <service id="session.storage.array" class="%session.storage.array.class%" public="false">
             <argument>%session.storage.array.options%</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -25,24 +25,25 @@
     </parameters>
 
     <services>
-        <service id="templating.engine" class="%templating.engine.class%">
+        <service id="templating.engine" class="%templating.engine.class%" public="false">
             <argument type="service" id="service_container" />
             <argument type="service" id="templating.loader" />
+            <argument type="collection" />
             <call method="setCharset"><argument>%kernel.charset%</argument></call>
         </service>
 
-        <service id="templating.loader.filesystem" class="%templating.loader.filesystem.class%">
+        <service id="templating.loader.filesystem" class="%templating.loader.filesystem.class%" public="false">
             <argument>%templating.loader.filesystem.path%</argument>
             <call method="setDebugger"><argument type="service" id="templating.debugger" on-invalid="ignore" /></call>
         </service>
 
-        <service id="templating.loader.cache" class="%templating.loader.cache.class%">
+        <service id="templating.loader.cache" class="%templating.loader.cache.class%" public="false">
             <argument type="service" id="templating.loader.wrapped" />
             <argument>%templating.loader.cache.path%</argument>
             <call method="setDebugger"><argument type="service" id="templating.debugger" on-invalid="ignore" /></call>
         </service>
 
-        <service id="templating.loader.chain" class="%templating.loader.chain.class%">
+        <service id="templating.loader.chain" class="%templating.loader.chain.class%" public="false">
             <call method="setDebugger"><argument type="service" id="templating.debugger" on-invalid="ignore" /></call>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="templating.debugger" class="%templating.debugger.class%">
+        <service id="templating.debugger" class="%templating.debugger.class%" public="false">
             <argument type="service" id="logger" on-invalid="null" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -30,7 +30,7 @@
             <argument type="service" id="translator.selector" />
         </service>
 
-        <service id="translator.selector" class="%translator.selector.class%" />
+        <service id="translator.selector" class="%translator.selector.class%" public="false" />
 
         <service id="translation.loader.php" class="%translation.loader.php.class%">
             <tag name="translation.loader" alias="php" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -16,36 +16,36 @@
     </parameters>
 
     <services>
-        <service id="controller_name_converter" class="%controller_name_converter.class%">
+        <service id="controller_name_converter" class="%controller_name_converter.class%" public="false">
             <argument type="service" id="kernel" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
-        <service id="controller_resolver" class="%controller_resolver.class%">
+        <service id="controller_resolver" class="%controller_resolver.class%" public="false">
             <argument type="service" id="service_container" />
             <argument type="service" id="controller_name_converter" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
-        <service id="request_listener" class="%request_listener.class%">
+        <service id="request_listener" class="%request_listener.class%" public="false">
             <tag name="kernel.listener" />
             <argument type="service" id="service_container" />
             <argument type="service" id="router" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
-        <service id="esi" class="%esi.class%" />
+        <service id="esi" class="%esi.class%" public="false" />
 
-        <service id="esi_listener" class="%esi_listener.class%">
+        <service id="esi_listener" class="%esi_listener.class%" public="false">
           <tag name="kernel.listener" />
           <argument type="service" id="esi" on-invalid="ignore" />
         </service>
 
-        <service id="response_listener" class="%response_listener.class%">
+        <service id="response_listener" class="%response_listener.class%" public="false">
             <tag name="kernel.listener" />
         </service>
 
-        <service id="exception_listener" class="%exception_listener.class%">
+        <service id="exception_listener" class="%exception_listener.class%" public="false">
             <tag name="kernel.listener" priority="128" />
             <argument>%exception_listener.controller%</argument>
             <argument type="service" id="logger" on-invalid="null" />

--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/swiftmailer.xml
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/swiftmailer.xml
@@ -30,12 +30,12 @@
   </parameters>
 
   <services>
-    <service id="swiftmailer.mailer" class="%swiftmailer.class%">
+    <service id="swiftmailer.mailer" class="%swiftmailer.class%" public="false">
       <argument type="service" id="swiftmailer.transport" />
       <file>%swiftmailer.init_file%</file>
     </service>
 
-    <service id="swiftmailer.transport.smtp" class="%swiftmailer.transport.smtp.class%">
+    <service id="swiftmailer.transport.smtp" class="%swiftmailer.transport.smtp.class%" public="false">
       <argument type="service" id="swiftmailer.transport.buffer" />
       <argument type="collection">
         <argument type="service" id="swiftmailer.transport.authhandler" />
@@ -50,25 +50,25 @@
       <call method="setAuthMode"><argument>%swiftmailer.transport.smtp.auth_mode%</argument></call>
     </service>
 
-    <service id="swiftmailer.transport.sendmail" class="%swiftmailer.transport.sendmail.class%">
+    <service id="swiftmailer.transport.sendmail" class="%swiftmailer.transport.sendmail.class%" public="false">
       <argument type="service" id="swiftmailer.transport.buffer" />
       <argument type="service" id="swiftmailer.transport.eventdispatcher" />
     </service>
 
-    <service id="swiftmailer.transport.mail" class="%swiftmailer.transport.mail.class%">
+    <service id="swiftmailer.transport.mail" class="%swiftmailer.transport.mail.class%" public="false">
       <argument type="service" id="swiftmailer.transport.mailinvoker" />
       <argument type="service" id="swiftmailer.transport.eventdispatcher" />
     </service>
 
-    <service id="swiftmailer.transport.failover" class="%swiftmailer.transport.failover.class%" />
+    <service id="swiftmailer.transport.failover" class="%swiftmailer.transport.failover.class%" public="false" />
 
-    <service id="swiftmailer.transport.mailinvoker" class="Swift_Transport_SimpleMailInvoker" />
+    <service id="swiftmailer.transport.mailinvoker" class="Swift_Transport_SimpleMailInvoker" public="false" />
 
-    <service id="swiftmailer.transport.buffer" class="Swift_Transport_StreamBuffer">
+    <service id="swiftmailer.transport.buffer" class="Swift_Transport_StreamBuffer" public="false">
       <argument type="service" id="swiftmailer.transport.replacementfactory" />
     </service>
 
-    <service id="swiftmailer.transport.authhandler" class="Swift_Transport_Esmtp_AuthHandler">
+    <service id="swiftmailer.transport.authhandler" class="Swift_Transport_Esmtp_AuthHandler" public="false">
       <argument type="collection">
         <argument type="service"><service class="Swift_Transport_Esmtp_Auth_CramMd5Authenticator" /></argument>
         <argument type="service"><service class="Swift_Transport_Esmtp_Auth_LoginAuthenticator" /></argument>
@@ -76,31 +76,31 @@
       </argument>
     </service>
 
-    <service id="swiftmailer.transport.eventdispatcher" class="Swift_Events_SimpleEventDispatcher" />
+    <service id="swiftmailer.transport.eventdispatcher" class="Swift_Events_SimpleEventDispatcher" public="false" />
 
-    <service id="swiftmailer.transport.replacementfactory" class="Swift_StreamFilters_StringReplacementFilterFactory" />
+    <service id="swiftmailer.transport.replacementfactory" class="Swift_StreamFilters_StringReplacementFilterFactory" public="false" />
 
-    <service id="swiftmailer.transport.spool" class="Swift_Transport_SpoolTransport">
+    <service id="swiftmailer.transport.spool" class="Swift_Transport_SpoolTransport" public="false">
       <argument type="service" id="swiftmailer.transport.eventdispatcher" />
       <argument type="service" id="swiftmailer.spool" />
     </service>
 
-    <service id="swiftmailer.transport.null" class="Swift_Transport_NullTransport">
+    <service id="swiftmailer.transport.null" class="Swift_Transport_NullTransport" public="false">
       <argument type="service" id="swiftmailer.transport.eventdispatcher" />
     </service>
 
-    <service id="swiftmailer.spool.file" class="%swiftmailer.spool.file.class%">
+    <service id="swiftmailer.spool.file" class="%swiftmailer.spool.file.class%" public="false">
       <argument>%swiftmailer.spool.file.path%</argument>
     </service>
 
-    <service id="swiftmailer.plugin.redirecting" class="%swiftmailer.plugin.redirecting.class%">
+    <service id="swiftmailer.plugin.redirecting" class="%swiftmailer.plugin.redirecting.class%" public="false">
       <argument>%swiftmailer.single_address%</argument>
     </service>
 
-    <service id="swiftmailer.plugin.blackhole" class="%swiftmailer.plugin.blackhole.class%" />
+    <service id="swiftmailer.plugin.blackhole" class="%swiftmailer.plugin.blackhole.class%" public="false" />
 
-    <service id="swiftmailer.transport" alias="swiftmailer.transport.smtp" />
+    <service id="swiftmailer.transport" alias="swiftmailer.transport.smtp" public="false" />
 
-    <service id="swiftmailer.spool" alias="swiftmailer.spool.file" />
+    <service id="swiftmailer.spool" alias="swiftmailer.spool.file" public="false" />
   </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -35,22 +35,22 @@
             <argument type="service" id="twig" />
         </service>
 
-        <service id="twig.extension.trans" class="Symfony\Bundle\TwigBundle\Extension\TransExtension">
+        <service id="twig.extension.trans" class="Symfony\Bundle\TwigBundle\Extension\TransExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="translator" />
         </service>
 
-        <service id="twig.extension.helpers" class="Symfony\Bundle\TwigBundle\Extension\TemplatingExtension">
+        <service id="twig.extension.helpers" class="Symfony\Bundle\TwigBundle\Extension\TemplatingExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="twig.extension.form" class="Symfony\Bundle\TwigBundle\Extension\FormExtension">
+        <service id="twig.extension.form" class="Symfony\Bundle\TwigBundle\Extension\FormExtension" public="false">
             <tag name="twig.extension" />
             <argument>%twig.form.resources%</argument>
         </service>
 
-        <service id="twig.security.form" class="Symfony\Bundle\TwigBundle\Extension\SecurityExtension">
+        <service id="twig.security.form" class="Symfony\Bundle\TwigBundle\Extension\SecurityExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="security.context" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="debug.toolbar" class="%debug.toolbar.class%">
+        <service id="debug.toolbar" class="%debug.toolbar.class%" public="false">
             <tag name="kernel.listener" priority="128" />
             <argument type="service" id="controller_resolver" />
             <argument>%debug.toolbar.intercept_redirects%</argument>

--- a/src/Symfony/Bundle/ZendBundle/Resources/config/logger.xml
+++ b/src/Symfony/Bundle/ZendBundle/Resources/config/logger.xml
@@ -18,23 +18,23 @@
     <services>
         <service id="zend.logger" class="%zend.logger.class%" />
 
-        <service id="zend.logger.writer.filesystem" class="%zend.logger.writer.filesystem.class%">
+        <service id="zend.logger.writer.filesystem" class="%zend.logger.writer.filesystem.class%" public="false">
             <tag name="zend.logger.writer" />
             <argument>%zend.logger.path%</argument>
             <call method="addFilter"><argument type="service" id="zend.logger.filter" /></call>
             <call method="setFormatter"><argument type="service" id="zend.formatter.filesystem" /></call>
         </service>
 
-        <service id="zend.formatter.filesystem" class="%zend.formatter.filesystem.class%">
+        <service id="zend.formatter.filesystem" class="%zend.formatter.filesystem.class%" public="false">
             <argument>%zend.formatter.filesystem.format%</argument>
         </service>
 
-        <service id="zend.logger.writer.debug" class="%zend.logger.writer.debug.class%">
+        <service id="zend.logger.writer.debug" class="%zend.logger.writer.debug.class%" public="false">
             <tag name="zend.logger.writer" />
             <call method="addFilter"><argument type="service" id="zend.logger.filter" /></call>
         </service>
 
-        <service id="zend.logger.filter" class="Zend\Log\Filter\Priority">
+        <service id="zend.logger.filter" class="Zend\Log\Filter\Priority" public="false">
             <argument>%zend.logger.priority%</argument>
         </service>
     </services>


### PR DESCRIPTION
This has been split off from the optimization commit. It changes the visibility of many services to public=false.

This will still allow you to have references from your services to the non-public services, but you may not be able to pull these services from the container directly ($container->get(...)). Non-public services can be optimized far more aggressively, so unless absolutely necessary you should define most of your services as non-public.

Everyone is encouraged to review the visibility changes. There may be valid use cases for letting them stay public which I have missed.
