### PR TITLE
Global template vars

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -30,6 +30,14 @@
             <argument type="service" id="templating.loader" />
             <argument type="collection" />
             <call method="setCharset"><argument>%kernel.charset%</argument></call>
+            <call method="setGlobal">
+                <argument>request</argument>
+                <argument type="service" id="request" />
+            </call>
+            <call method="setGlobal">
+                <argument>session</argument>
+                <argument type="service" id="session" />
+            </call>
         </service>
 
         <service id="templating.loader.filesystem" class="%templating.loader.filesystem.class%" public="false">

--- a/src/Symfony/Bundle/TwigBundle/Renderer/Renderer.php
+++ b/src/Symfony/Bundle/TwigBundle/Renderer/Renderer.php
@@ -37,11 +37,6 @@ class Renderer extends BaseRenderer
      */
     public function evaluate(Storage $template, array $parameters = array())
     {
-        // cannot be set in the constructor as we need the current request
-        $request = $this->engine->getContainer()->get('request');
-        $this->environment->addGlobal('request', $request);
-        $this->environment->addGlobal('session', $request->getSession());
-
         return $this->environment->loadTemplate($template)->render($parameters);
     }
 }

--- a/src/Symfony/Component/Templating/Engine.php
+++ b/src/Symfony/Component/Templating/Engine.php
@@ -406,7 +406,7 @@ class Engine implements \ArrayAccess
      * @param string $name
      * @param mixed $value
      */
-    public function addGlobal($name, $value)
+    public function setGlobal($name, $value)
     {
         $this->globals[$name] = $value;
     }

--- a/tests/Symfony/Tests/Component/Templating/EngineTest.php
+++ b/tests/Symfony/Tests/Component/Templating/EngineTest.php
@@ -135,7 +135,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
     public function testGlobalVariables()
     {
         $engine = new ProjectTemplateEngine(self::$loader);
-        $engine->addGlobal('global_variable', 'lorem ipsum');
+        $engine->setGlobal('global_variable', 'lorem ipsum');
 
         $this->assertEquals(array(
             'global_variable' => 'lorem ipsum',
@@ -145,7 +145,7 @@ class EngineTest extends \PHPUnit_Framework_TestCase
     public function testGlobalsGetPassedToTemplate()
     {
         $engine = new ProjectTemplateEngine(self::$loader);
-        $engine->addGlobal('global', 'global variable');
+        $engine->setGlobal('global', 'global variable');
 
         self::$loader->setTemplate('global.php', '<?php echo $global; ?>');
 


### PR DESCRIPTION
Moved session and request global parameters from twig to the templating component. renamed addGlobal to setGlobal as a previously defined key will be overwritten.
