### PR TITLE
Fix bug in my previous Twig Renderer::evaluate() pull request

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Renderer/Renderer.php
+++ b/src/Symfony/Bundle/TwigBundle/Renderer/Renderer.php
@@ -37,9 +37,10 @@ class Renderer extends BaseRenderer
      */
     public function evaluate(Storage $template, array $parameters = array())
     {
-        if ($this->engine->getContainer()->has('request')) {
-            // cannot be set in the constructor as we need the current request
-            $request = $this->engine->getContainer()->get('request');
+        $container = $this->engine->getContainer();
+
+        // cannot be set in the constructor as we need the current request
+        if ($container->has('request') && ($request = $container->get('request'))) {
             $this->environment->addGlobal('request', $request);
             $this->environment->addGlobal('session', $request->getSession());
         }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Renderer/RendererTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Renderer/RendererTest.php
@@ -42,7 +42,8 @@ class RendererTest extends TestCase
         $environment = $this->getTwigEnvironment();
         $renderer = new Renderer($environment);
 
-        $engine = new Engine(new Container(), $this->getMock('Symfony\Component\Templating\Loader\LoaderInterface'), array());
+        $container = new Container();
+        $engine = new Engine($container, $this->getMock('Symfony\Component\Templating\Loader\LoaderInterface'), array());
 
         $storage = $this->getStorage();
         $template = $this->getMock('\Twig_TemplateInterface');
@@ -52,6 +53,7 @@ class RendererTest extends TestCase
             ->with($storage)
             ->will($this->returnValue($template));
 
+        $container->set('request', null);
         $renderer->setEngine($engine);
         $renderer->evaluate($storage);
 


### PR DESCRIPTION
Also updated test case to catch my oversight.

Since Request service is defined with factory methods, the container will always **have** it, but it could certainly be null.  Added extra logic to ensure it is both _had_ and non-empty.
