### PR TITLE
Fix regex in DoctrineCommand

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -106,7 +106,7 @@ abstract class DoctrineCommand extends Command
         $connections = array();
         $ids = $this->container->getServiceIds();
         foreach ($ids as $id) {
-            preg_match('/doctrine.dbal.(.*)_connection/', $id, $matches);
+            preg_match('^doctrine\.dbal\.(.*)_connection$', $id, $matches);
             if ($matches) {
                 $name = $matches[1];
                 $connections[$name] = $this->container->get($id);
@@ -121,12 +121,13 @@ abstract class DoctrineCommand extends Command
         $entityManagers = array();
         $ids = $this->container->getServiceIds();
         foreach ($ids as $id) {
-            preg_match('/doctrine.orm.(.*)_entity_manager/', $id, $matches);
+            preg_match('/^doctrine\.orm\.(.*)_entity_manager$/', $id, $matches);
             if ($matches) {
                 $name = $matches[1];
                 $entityManagers[$name] = $this->container->get($id);
             }
         }
+
         return $entityManagers;
     }
 


### PR DESCRIPTION
8cc440f3e90d1cf0feb8401af5db1dbf338b330b [DoctrineBundle] Fixed invalid regex in DoctrineCommand 
