### PR TITLE
Switch pass order

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -39,8 +39,8 @@ class PassConfig
         $this->removingPasses = array(
             new RemovePrivateAliasesPass(),
             new ReplaceAliasByActualDefinitionPass(),
-            new InlineServiceDefinitionsPass(),
             new RemoveUnusedDefinitionsPass(),
+            new InlineServiceDefinitionsPass(),
         );
     }
 


### PR DESCRIPTION
This is necessary to catch all inline-able definitions.
