### PR TITLE
Move and rename file

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -516,10 +516,8 @@ class File
      */
     public function getExtension()
     {
-        $name = $this->getName();
-
-        if (false !== ($pos = strrpos($name, '.'))) {
-            return substr($name, $pos);
+        if ($ext = pathinfo($this->getName(), \PATHINFO_EXTENSION)) {
+            return '.' . $ext;
         } else {
             return '';
         }
@@ -634,11 +632,16 @@ class File
     /**
      * Moves the file to a new location.
      *
-     * @param string $directory
+     * @param string $directory   The destination folder
+     * @param string $name        The new file name
      */
-    public function move($directory)
+    public function move($directory, $name = null)
     {
         $this->doMove($directory, $this->getName());
+
+        if (null !== $name) {
+            $this->rename($name);
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -144,12 +144,16 @@ class UploadedFile extends File
     /**
      * @inheritDoc
      */
-    public function move($directory)
+    public function move($directory, $name = null)
     {
         if (!$this->moved) {
             $this->doMove($directory, $this->originalName);
+
+            if (null !== $name) {
+                $this->rename($name);
+            }
         } else {
-            parent::move($directory);
+            parent::move($directory, $name);
         }
     }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
@@ -93,6 +93,26 @@ class FileTest extends \PHPUnit_Framework_TestCase
         @unlink($targetPath);
     }
 
+    public function testMoveWithNewName()
+    {
+        $path = __DIR__.'/Fixtures/test.copy.gif';
+        $targetDir = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'directory';
+        $targetPath = $targetDir.DIRECTORY_SEPARATOR.'test.newname.gif';
+        @unlink($path);
+        @unlink($targetPath);
+        copy(__DIR__.'/Fixtures/test.gif', $path);
+
+        $file = new File($path);
+        $file->move($targetDir, 'test.newname.gif');
+
+        $this->assertTrue(file_exists($targetPath));
+        $this->assertFalse(file_exists($path));
+        $this->assertEquals($targetPath, $file->getPath());
+
+        @unlink($path);
+        @unlink($targetPath);
+    }
+
     public function testRename()
     {
         $path = __DIR__.'/Fixtures/test.copy.gif';


### PR DESCRIPTION
Hi Fabien,

I have updated both File::move() and UploadedFile::move() method to accept a second argument, which is the new name of the file to move.

It allows to move the file with a new name in one single pass.

$file->move(**DIR** . '/images', 'the-new-name.jpg');

Hugo.
