### PR TITLE
[HttpKernel] No longer reformat {} "a la python"

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -446,9 +446,6 @@ abstract class Kernel implements HttpKernelInterface, \Serializable
         // replace multiple new lines with a single newline
         $output = preg_replace(array('/\s+$/Sm', '/\n+/S'), "\n", $output);
 
-        // reformat {} "a la python"
-        $output = preg_replace(array('/\n\s*\{/', '/\n\s*\}/'), array(' {', ' }'), $output);
-
         return $output;
     }
 


### PR DESCRIPTION
Kernel::stripComments() removes the newline before closing braces. This breaks heredoc syntax. While it's possible to hack around that ([ugly hack](https://github.com/igorw/symfony/compare/strip-comments-heredoc-ugly)), it would be much easier to just remove that behaviour.

I encountered this when trying to use YAML parsing with Silex. Since the Silex compiler uses stripComments before compiling the phar, it will lead to parse errors.
