### PR TITLE
Acl config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_acl.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_acl.xml
@@ -26,7 +26,7 @@
     </parameters>
 
     <services>
-        <service id="security.acl.dbal.connection" alias="doctrine.dbal.default_connection" public="false" />
+        <service id="security.acl.dbal.connection" alias="doctrine.dbal.default_connection" />
     
         <service id="security.acl.object_identity_retrieval_strategy" class="%security.acl.object_identity_retrieval_strategy.class%" public="false"></service>
         


### PR DESCRIPTION
The acl:init command needs security.acl.dbal.connection, it has been made public again
