### PR TITLE
Request files fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -950,6 +950,10 @@ class Request
             if (is_array($data)) {
                 $keys = array_keys($data);
                 sort($keys);
+                
+                if ($keys == $fileKeys) {
+                    $data['error'] = (int) $data['error'];
+                }
 
                 if ($keys != $fileKeys) {
                     $fixedFiles[$key] = $this->convertFileInformation($data);


### PR DESCRIPTION
File upload in testing was breaking if no file uploaded.
It wasn't recognizing `UPLOAD_ERR_NO_FILE` because error code was casted to string in `parse_str(http_build_query($files))`
