### PR TITLE
Visibility db connections services

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -118,7 +118,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
             $driverOptions = array();
             $driverDef = new Definition('Doctrine\DBAL\DriverManager');
-            $driverDef->setPublic(false);
             $driverDef->setFactoryMethod('getConnection');
             $container->setDefinition(sprintf('doctrine.dbal.%s_connection', $connection['name']), $driverDef);
         }


### PR DESCRIPTION
Doctrine commands didn't work because they couldn't find a doctrine connection. I've found that the problem came from a visibility change to the doctrine db connection service/s. Just deleted the line that sets the services as private.

More info in:

http://groups.google.com/group/symfony-devs/browse_thread/thread/1cacf3da5121179d?hl=en#
