### PR TITLE
[FrameworkBundle] removed public=false from security.encoder_factory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -97,7 +97,7 @@
             <argument type="collection"></argument>
         </service>
         
-        <service id="security.encoder_factory" alias="security.encoder_factory.generic" public="false"></service>
+        <service id="security.encoder_factory" alias="security.encoder_factory.generic"></service>
 
         <service id="security.logout.handler.session" class="%security.logout.handler.session.class%" public="false"></service>
 


### PR DESCRIPTION
This is necessary to get this working:

http://docs.symfony-reloaded.org/master/guides/security/users.html#encoding-passwords
