### PR TITLE
Shared authentication manager

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAuthenticationProvidersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAuthenticationProvidersPass.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddAuthenticationProvidersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('security.authentication.manager')) {
+            return;
+        }
+
+        $providers = array();
+        foreach ($container->findTaggedServiceIds('security.authentication_provider') as $id => $attributes) {
+            $providers[] = new Reference($id);
+        }
+
+        $container
+            ->getDefinition('security.authentication.manager')
+            ->setArguments(array($providers))
+        ;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -26,16 +26,16 @@ class FormLoginFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->register($provider, '%security.authentication.provider.dao.class%')
-            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder_factory')))
+            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), $id, new Reference('security.encoder_factory')))
             ->setPublic(false)
+            ->addTag('security.authentication_provider')
         ;
 
         // listener
         $listenerId = 'security.authentication.listener.form.'.$id;
         $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.authentication.listener.form'));
         $arguments = $listener->getArguments();
-        $arguments[1] = new Reference($provider);
-        $listener->setArguments($arguments);
+        $arguments[2] = $id;
 
         $options = array(
             'check_path'                     => '/login_check',
@@ -53,7 +53,9 @@ class FormLoginFactory implements SecurityFactoryInterface
                 $options[$key] = $config[$key];
             }
         }
-        $container->setParameter('security.authentication.form.options', $options);
+        $arguments[3] = $options;
+        $listener->setArguments($arguments);
+
         $container->setParameter('security.authentication.form.login_path', $options['login_path']);
         $container->setParameter('security.authentication.form.use_forward', $options['use_forward']);
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -26,15 +26,16 @@ class HttpBasicFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->register($provider, '%security.authentication.provider.dao.class%')
-            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder_factory')))
+            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), $id, new Reference('security.encoder_factory')))
             ->setPublic(false)
+            ->addTag('security.authentication_provider')
         ;
 
         // listener
         $listenerId = 'security.authentication.listener.basic.'.$id;
         $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.authentication.listener.basic'));
         $arguments = $listener->getArguments();
-        $arguments[1] = new Reference($provider);
+        $arguments[2] = $id;
         $listener->setArguments($arguments);
 
         if (isset($config['path'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -26,8 +26,9 @@ class HttpDigestFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->register($provider, '%security.authentication.provider.dao.class%')
-            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), new Reference('security.encoder_factory')))
+            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), $id, new Reference('security.encoder_factory')))
             ->setPublic(false)
+            ->addTag('security.authentication_provider')
         ;
 
         // listener
@@ -35,6 +36,7 @@ class HttpDigestFactory implements SecurityFactoryInterface
         $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.authentication.listener.digest'));
         $arguments = $listener->getArguments();
         $arguments[1] = new Reference($userProvider);
+        $arguments[2] = $id;
         $listener->setArguments($arguments);
 
         if (null === $defaultEntryPoint) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/X509Factory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/X509Factory.php
@@ -26,15 +26,16 @@ class X509Factory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.pre_authenticated.'.$id;
         $container
             ->register($provider, '%security.authentication.provider.pre_authenticated.class%')
-            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker')))
+            ->setArguments(array(new Reference($userProvider), new Reference('security.account_checker'), $id))
             ->setPublic(false)
+            ->addTag('security.authentication_provider')
         ;
 
         // listener
         $listenerId = 'security.authentication.listener.x509.'.$id;
         $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.authentication.listener.x509'));
         $arguments = $listener->getArguments();
-        $arguments[1] = new Reference($provider);
+        $arguments[2] = $id;
         $listener->setArguments($arguments);
 
         return array($provider, $listenerId, $defaultEntryPoint);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\RequestMatcher;
  * SecurityExtension.
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class SecurityExtension extends Extension
 {
@@ -247,7 +248,7 @@ class SecurityExtension extends Extension
         $listeners = array_merge($listeners, $authListeners);
 
         // Access listener
-        $listeners[] = new Reference($this->createAccessListener($container, $id, $providers));
+        $listeners[] = new Reference('security.access_listener');
 
         // Switch user listener
         if (array_key_exists('switch_user', $firewall)) {
@@ -523,26 +524,6 @@ class SecurityExtension extends Extension
     protected function getUserProviderId($name)
     {
         return 'security.authentication.provider.'.$name;
-    }
-
-    protected function createAccessListener($container, $id, $providers)
-    {
-        // Authentication manager
-        $authManager = 'security.authentication.manager.'.$id;
-        $container
-            ->register($authManager, '%security.authentication.manager.class%')
-            ->addArgument($providers)
-            ->setPublic(false)
-        ;
-
-        // Access listener
-        $listenerId = 'security.access_listener.'.$id;
-        $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.access_listener'));
-        $arguments = $listener->getArguments();
-        $arguments[3] = new Reference($authManager);
-        $listener->setArguments($arguments);
-
-        return $listenerId;
     }
 
     protected function createExceptionListener($container, $id, $defaultEntryPoint)

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle;
 
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAuthenticationProvidersPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddTemplatingRenderersPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RegisterKernelListenersPass;
@@ -66,5 +67,6 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterKernelListenersPass());
         $container->addCompilerPass(new AddTemplatingRenderersPass());
         $container->addCompilerPass(new AddConstraintValidatorsPass());
+        $container->addCompilerPass(new AddAuthenticationProvidersPass());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="security.context.class">Symfony\Component\Security\SecurityContext</parameter>
+        <parameter key="security.context.always_authenticate">false</parameter>
 
         <parameter key="security.account_checker.class">Symfony\Component\Security\User\AccountChecker</parameter>
 
@@ -48,6 +49,8 @@
         <parameter key="security.authentication.listener.basic.class">Symfony\Component\HttpKernel\Security\Firewall\BasicAuthenticationListener</parameter>
         <parameter key="security.authentication.listener.digest.class">Symfony\Component\HttpKernel\Security\Firewall\DigestAuthenticationListener</parameter>
         <parameter key="security.authentication.listener.anonymous.class">Symfony\Component\HttpKernel\Security\Firewall\AnonymousAuthenticationListener</parameter>
+        
+        <parameter key="security.authentication.provider.anonymous">Symfony\Component\Security\Authentication\Provider\AnonymousAuthenticationProvider</parameter>
         <parameter key="security.anonymous.key">SomeRandomValue</parameter>
 
         <parameter key="security.channel_listener.class">Symfony\Component\HttpKernel\Security\Firewall\ChannelListener</parameter>
@@ -84,7 +87,9 @@
 
     <services>
         <service id="security.context" class="%security.context.class%">
+            <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.access.decision_manager" />
+            <argument>%security.context.always_authenticate%</argument>
         </service>
 
         <service id="security.role_hierarchy" class="%security.role_hierarchy.class%" public="false">
@@ -105,6 +110,15 @@
             <argument type="service" id="security.context" />
             <argument>%security.anonymous.key%</argument>
             <argument type="service" id="logger" on-invalid="null" />
+        </service>
+
+        <service id="security.authentication.manager" class="%security.authentication.manager.class%" public="false">
+            <argument type="collection" />
+        </service>
+        
+        <service id="security.authentication.provider.anonymous" class="%security.authentication.provider.anonymous%" public="false">
+            <argument>%security.anonymous.key%</argument>
+            <tag name="security.authentication_provider" />
         </service>
 
         <service id="security.authentication.trust_resolver" class="%security.authentication.trust_resolver.class%" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
@@ -34,6 +34,7 @@
         <service id="security.authentication.listener.form" class="%security.authentication.listener.form.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
+            <argument />
             <argument>%security.authentication.form.options%</argument>
             <argument type="service" id="logger" on-invalid="null" />
         </service>
@@ -41,6 +42,7 @@
         <service id="security.authentication.listener.x509" class="%security.authentication.listener.x509.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
+            <argument />
             <argument>%security.authentication.x509.user%</argument>
             <argument>%security.authentication.x509.credentials%</argument>
             <argument type="service" id="logger" on-invalid="null" />
@@ -49,6 +51,7 @@
         <service id="security.authentication.listener.basic" class="%security.authentication.listener.basic.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
+            <argument></argument>
             <argument type="service" id="security.authentication.basic_entry_point" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
@@ -56,6 +59,7 @@
         <service id="security.authentication.listener.digest" class="%security.authentication.listener.digest.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.user.provider.in_memory" />
+            <argument></argument>
             <argument type="service" id="security.authentication.digest_entry_point" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/BasicAuthenticationListener.php
@@ -29,21 +29,27 @@ class BasicAuthenticationListener implements ListenerInterface
 {
     protected $securityContext;
     protected $authenticationManager;
+    protected $providerKey;
     protected $authenticationEntryPoint;
     protected $logger;
     protected $ignoreFailure;
 
-    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, AuthenticationEntryPointInterface $authenticationEntryPoint, LoggerInterface $logger = null)
+    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, AuthenticationEntryPointInterface $authenticationEntryPoint, LoggerInterface $logger = null)
     {
+        if (empty($providerKey)) {
+            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        }
+
         $this->securityContext = $securityContext;
         $this->authenticationManager = $authenticationManager;
+        $this->providerKey = $providerKey;
         $this->authenticationEntryPoint = $authenticationEntryPoint;
         $this->logger = $logger;
         $this->ignoreFailure = false;
     }
 
     /**
-     * 
+     *
      *
      * @param EventDispatcher $dispatcher An EventDispatcher instance
      * @param integer         $priority   The priority
@@ -52,7 +58,7 @@ class BasicAuthenticationListener implements ListenerInterface
     {
         $dispatcher->connect('core.security', array($this, 'handle'), 0);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -88,7 +94,7 @@ class BasicAuthenticationListener implements ListenerInterface
         }
 
         try {
-            $token = $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $request->server->get('PHP_AUTH_PW')));
+            $token = $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $request->server->get('PHP_AUTH_PW'), $this->providerKey));
             $this->securityContext->setToken($token);
         } catch (AuthenticationException $failed) {
             $this->securityContext->setToken(null);

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
@@ -148,10 +148,18 @@ class ContextListener implements ListenerInterface
                     $token->setAuthenticated(false);
                 }
 
+                if (null !== $this->logger) {
+                    $this->logger->debug(sprintf('Username "%s" was reloaded from user provider.', $user));
+                }
+
                 return $token;
             } catch (UnsupportedAccountException $unsupported) {
                 // let's try the next user provider
             } catch (UsernameNotFoundException $notFound) {
+                if (null !== $this->logger) {
+                    $this->logger->debug(sprintf('Username "%s" could not be found.', $user));
+                }
+
                 return null;
             }
         }

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/DigestAuthenticationListener.php
@@ -34,19 +34,25 @@ class DigestAuthenticationListener implements ListenerInterface
 {
     protected $securityContext;
     protected $provider;
+    protected $providerKey;
     protected $authenticationEntryPoint;
     protected $logger;
 
-    public function __construct(SecurityContext $securityContext, UserProviderInterface $provider, DigestAuthenticationEntryPoint $authenticationEntryPoint, LoggerInterface $logger = null)
+    public function __construct(SecurityContext $securityContext, UserProviderInterface $provider, $providerKey, DigestAuthenticationEntryPoint $authenticationEntryPoint, LoggerInterface $logger = null)
     {
+        if (empty($providerKey)) {
+            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        }
+
         $this->securityContext = $securityContext;
         $this->provider = $provider;
+        $this->providerKey = $providerKey;
         $this->authenticationEntryPoint = $authenticationEntryPoint;
         $this->logger = $logger;
     }
 
     /**
-     * 
+     *
      *
      * @param EventDispatcher $dispatcher An EventDispatcher instance
      * @param integer         $priority   The priority
@@ -55,7 +61,7 @@ class DigestAuthenticationListener implements ListenerInterface
     {
         $dispatcher->connect('core.security', array($this, 'handle'), 0);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -134,7 +140,7 @@ class DigestAuthenticationListener implements ListenerInterface
             $this->logger->debug(sprintf('Authentication success for user "%s" with response "%s"', $digestAuth->getUsername(), $digestAuth->getResponse()));
         }
 
-        $this->securityContext->setToken(new UsernamePasswordToken($user, $user->getPassword()));
+        $this->securityContext->setToken(new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey));
     }
 
     protected function fail(Request $request, AuthenticationException $failed)

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/PreAuthenticatedListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/PreAuthenticatedListener.php
@@ -31,17 +31,19 @@ abstract class PreAuthenticatedListener implements ListenerInterface
 {
     protected $securityContext;
     protected $authenticationManager;
+    protected $providerKey;
     protected $logger;
 
-    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger = null)
+    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, LoggerInterface $logger = null)
     {
         $this->securityContext = $securityContext;
         $this->authenticationManager = $authenticationManager;
+        $this->providerKey = $providerKey;
         $this->logger = $logger;
     }
 
     /**
-     * 
+     *
      *
      * @param EventDispatcher $dispatcher An EventDispatcher instance
      * @param integer         $priority   The priority
@@ -50,14 +52,14 @@ abstract class PreAuthenticatedListener implements ListenerInterface
     {
         $dispatcher->connect('core.security', array($this, 'handle'), 0);
     }
-    
+
     /**
      * {@inheritDoc}
      */
     public function unregister(EventDispatcher $dispatcher)
     {
     }
-    
+
     /**
      * Handles X509 authentication.
      *
@@ -88,7 +90,7 @@ abstract class PreAuthenticatedListener implements ListenerInterface
         }
 
         try {
-            $token = $this->authenticationManager->authenticate(new PreAuthenticatedToken($user, $credentials));
+            $token = $this->authenticationManager->authenticate(new PreAuthenticatedToken($user, $credentials, $this->providerKey));
 
             if (null !== $this->logger) {
                 $this->logger->debug(sprintf('Authentication success: %s', $token));

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/SwitchUserListener.php
@@ -37,6 +37,7 @@ class SwitchUserListener implements ListenerInterface
     protected $securityContext;
     protected $provider;
     protected $accountChecker;
+    protected $providerKey;
     protected $accessDecisionManager;
     protected $usernameParameter;
     protected $role;
@@ -45,11 +46,16 @@ class SwitchUserListener implements ListenerInterface
     /**
      * Constructor.
      */
-    public function __construct(SecurityContext $securityContext, UserProviderInterface $provider, AccountCheckerInterface $accountChecker, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, $usernameParameter = '_switch_user', $role = 'ROLE_ALLOWED_TO_SWITCH')
+    public function __construct(SecurityContext $securityContext, UserProviderInterface $provider, AccountCheckerInterface $accountChecker, $providerKey, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, $usernameParameter = '_switch_user', $role = 'ROLE_ALLOWED_TO_SWITCH')
     {
+        if (empty($providerKey)) {
+            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        }
+
         $this->securityContext = $securityContext;
         $this->provider = $provider;
         $this->accountChecker = $accountChecker;
+        $this->providerKey = $providerKey;
         $this->accessDecisionManager = $accessDecisionManager;
         $this->usernameParameter = $usernameParameter;
         $this->role = $role;
@@ -57,7 +63,7 @@ class SwitchUserListener implements ListenerInterface
     }
 
     /**
-     * 
+     *
      *
      * @param EventDispatcher $dispatcher An EventDispatcher instance
      * @param integer         $priority   The priority
@@ -66,14 +72,14 @@ class SwitchUserListener implements ListenerInterface
     {
         $dispatcher->connect('core.security', array($this, 'handle'), 0);
     }
-    
+
     /**
      * {@inheritDoc}
      */
     public function unregister(EventDispatcher $dispatcher)
     {
     }
-    
+
     /**
      * Handles digest authentication.
      *
@@ -136,7 +142,7 @@ class SwitchUserListener implements ListenerInterface
         $roles = $user->getRoles();
         $roles[] = new SwitchUserRole('ROLE_PREVIOUS_ADMIN', $this->securityContext->getToken());
 
-        $token = new UsernamePasswordToken($user, $user->getPassword(), $roles);
+        $token = new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey, $roles);
         $token->setImmutable(true);
 
         return $token;

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -25,16 +25,24 @@ use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
  */
 class UsernamePasswordFormAuthenticationListener extends FormAuthenticationListener
 {
+    protected $providerKey;
+
     /**
      * {@inheritdoc}
      */
-    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, array $options = array(), LoggerInterface $logger = null)
+    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, array $options = array(), LoggerInterface $logger = null)
     {
         parent::__construct($securityContext, $authenticationManager, array_merge(array(
             'username_parameter' => '_username',
             'password_parameter' => '_password',
             'post_only'          => true,
         ), $options), $logger);
+
+        if (empty($providerKey)) {
+            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        }
+
+        $this->providerKey = $providerKey;
     }
 
     /**
@@ -55,6 +63,6 @@ class UsernamePasswordFormAuthenticationListener extends FormAuthenticationListe
 
         $request->getSession()->set(SecurityContext::LAST_USERNAME, $username);
 
-        return $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $password));
+        return $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $password, $this->providerKey));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/X509AuthenticationListener.php
@@ -27,9 +27,9 @@ class X509AuthenticationListener extends PreAuthenticatedListener
     protected $userKey;
     protected $credentialKey;
 
-    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, $userKey = 'SSL_CLIENT_S_DN_Email', $credentialKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null)
+    public function __construct(SecurityContext $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, $userKey = 'SSL_CLIENT_S_DN_Email', $credentialKey = 'SSL_CLIENT_S_DN', LoggerInterface $logger = null)
     {
-        parent::__construct($securityContext, $authenticationManager, $logger);
+        parent::__construct($securityContext, $authenticationManager, $providerKey, $logger);
 
         $this->userKey = $userKey;
         $this->credentialKey = $credentialKey;

--- a/src/Symfony/Component/Security/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Authentication/Provider/DaoAuthenticationProvider.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\Security\Authentication\Provider;
 
+use Symfony\Component\Security\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\User\UserProviderInterface;
 use Symfony\Component\Security\User\AccountCheckerInterface;
@@ -38,9 +39,9 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
      * @param AccountCheckerInterface  $accountChecker  An AccountCheckerInterface instance
      * @param EncoderFactoryInterface  $encoderFactory  A EncoderFactoryInterface instance
      */
-    public function __construct(UserProviderInterface $userProvider, AccountCheckerInterface $accountChecker, EncoderFactoryInterface $encoderFactory, $hideUserNotFoundExceptions = true)
+    public function __construct(UserProviderInterface $userProvider, AccountCheckerInterface $accountChecker, $providerKey, EncoderFactoryInterface $encoderFactory, $hideUserNotFoundExceptions = true)
     {
-        parent::__construct($accountChecker, $hideUserNotFoundExceptions);
+        parent::__construct($accountChecker, $providerKey, $hideUserNotFoundExceptions);
 
         $this->encoderFactory = $encoderFactory;
         $this->userProvider = $userProvider;

--- a/src/Symfony/Component/Security/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\Security\Authentication\Provider;
 
+use Symfony\Component\Security\User\AccountInterface;
 use Symfony\Component\Security\User\UserProviderInterface;
 use Symfony\Component\Security\User\AccountCheckerInterface;
 use Symfony\Component\Security\Exception\BadCredentialsException;
@@ -31,6 +32,7 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
 {
     protected $userProvider;
     protected $accountChecker;
+    protected $providerKey;
 
     /**
      * Constructor.
@@ -38,10 +40,11 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
      * @param UserProviderInterface   $userProvider   A UserProviderInterface instance
      * @param AccountCheckerInterface $accountChecker An AccountCheckerInterface instance
      */
-    public function __construct(UserProviderInterface $userProvider, AccountCheckerInterface $accountChecker)
+    public function __construct(UserProviderInterface $userProvider, AccountCheckerInterface $accountChecker, $providerKey)
     {
         $this->userProvider = $userProvider;
         $this->accountChecker = $accountChecker;
+        $this->providerKey = $providerKey;
     }
 
      /**
@@ -73,6 +76,6 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
      */
     public function supports(TokenInterface $token)
     {
-        return $token instanceof PreAuthenticatedToken;
+        return $token instanceof PreAuthenticatedToken && $this->providerKey === $token->getProviderKey();
     }
 }

--- a/src/Symfony/Component/Security/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Authentication/Token/PreAuthenticatedToken.php
@@ -18,10 +18,12 @@ namespace Symfony\Component\Security\Authentication\Token;
  */
 class PreAuthenticatedToken extends Token
 {
+    protected $providerKey;
+
     /**
      * Constructor.
      */
-    public function __construct($user, $credentials, array $roles = null)
+    public function __construct($user, $credentials, $providerKey, array $roles = null)
     {
         parent::__construct(null === $roles ? array() : $roles);
         if (null !== $roles) {
@@ -30,6 +32,12 @@ class PreAuthenticatedToken extends Token
 
         $this->user = $user;
         $this->credentials = $credentials;
+        $this->providerKey = $providerKey;
+    }
+
+    public function getProviderKey()
+    {
+        return $this->providerKey;
     }
 
     /**

--- a/src/Symfony/Component/Security/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Authentication/Token/RememberMeToken.php
@@ -13,6 +13,7 @@ use Symfony\Component\Security\User\AccountInterface;
 class RememberMeToken extends Token
 {
     protected $key;
+    protected $providerKey;
 
     /**
      * The persistent token which resulted in this authentication token.
@@ -27,7 +28,7 @@ class RememberMeToken extends Token
      * @param string $username
      * @param string $key
      */
-    public function __construct(AccountInterface $user, $key) {
+    public function __construct(AccountInterface $user, $providerKey, $key) {
         parent::__construct($user->getRoles());
 
         if (0 === strlen($key)) {
@@ -35,8 +36,14 @@ class RememberMeToken extends Token
         }
 
         $this->user = $user;
+        $this->providerKey = $providerKey;
         $this->key = $key;
         $this->setAuthenticated(true);
+    }
+
+    public function getProviderKey()
+    {
+        return $this->providerKey;
     }
 
     public function getKey()

--- a/src/Symfony/Component/Security/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Authentication/Token/UsernamePasswordToken.php
@@ -18,17 +18,25 @@ namespace Symfony\Component\Security\Authentication\Token;
  */
 class UsernamePasswordToken extends Token
 {
+    protected $providerKey;
+
     /**
      * Constructor.
      */
-    public function __construct($user, $credentials, array $roles = array())
+    public function __construct($user, $credentials, $providerKey, array $roles = array())
     {
         parent::__construct($roles);
 
         $this->setUser($user);
         $this->credentials = $credentials;
+        $this->providerKey = $providerKey;
 
         parent::setAuthenticated((Boolean) count($roles));
+    }
+
+    public function getProviderKey()
+    {
+        return $this->providerKey;
     }
 
     /**

--- a/src/Symfony/Component/Security/SecurityContext.php
+++ b/src/Symfony/Component/Security/SecurityContext.php
@@ -2,6 +2,8 @@
 
 namespace Symfony\Component\Security;
 
+use Symfony\Component\Security\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
@@ -30,15 +32,19 @@ class SecurityContext
 
     protected $token;
     protected $accessDecisionManager;
+    protected $authenticationManager;
+    protected $alwaysAuthenticate;
 
     /**
      * Constructor.
      *
-     * @param AccessDecisionManager|null $accessDecisionManager An AccessDecisionManager instance
+     * @param AccessDecisionManagerInterface|null $accessDecisionManager An AccessDecisionManager instance
      */
-    public function __construct(AccessDecisionManager $accessDecisionManager = null)
+    public function __construct(AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager = null, $alwaysAuthenticate = false)
     {
+        $this->authenticationManager = $authenticationManager;
         $this->accessDecisionManager = $accessDecisionManager;
+        $this->alwaysAuthenticate = $alwaysAuthenticate;
     }
 
     public function getUser()
@@ -58,6 +64,10 @@ class SecurityContext
             }
 
             $object = new FieldVote($object, $field);
+        }
+
+        if ($this->alwaysAuthenticate || !$this->token->isAuthenticated()) {
+            $this->token = $this->authenticationManager->authenticate($this->token);
         }
 
         return $this->accessDecisionManager->decide($this->token, (array) $attributes, $object);

--- a/src/Symfony/Component/Security/User/User.php
+++ b/src/Symfony/Component/Security/User/User.php
@@ -119,7 +119,6 @@ class User implements AdvancedAccountInterface
      */
     public function eraseCredentials()
     {
-        $this->password = null;
     }
 
     /**

--- a/src/Symfony/Component/Security/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/User/UserProviderInterface.php
@@ -36,13 +36,13 @@ interface UserProviderInterface
       * Loads the user for the account interface.
       *
       * It is up to the implementation if it decides to reload the user data
-      * from the database, or if it simply merges the passed User into the 
+      * from the database, or if it simply merges the passed User into the
       * identity map of an entity manager.
       *
       * @throws UnsupportedAccountException if the account is not supported
-      * @param AccountInterface $user
+      * @param AccountInterface $account
       *
       * @return AccountInterface
       */
-     function loadUserByAccount(AccountInterface $user);
+     function loadUserByAccount(AccountInterface $account);
 }

--- a/tests/Symfony/Tests/Component/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/tests/Symfony/Tests/Component/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -104,14 +104,14 @@ class AuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
     public function testEraseCredentialFlag()
     {
         $manager = new AuthenticationProviderManager(array(
-            $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar')),
+            $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar', 'key')),
         ));
 
         $token = $manager->authenticate($this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface'));
         $this->assertEquals('', $token->getCredentials());
 
         $manager = new AuthenticationProviderManager(array(
-            $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar')),
+            $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar', 'key')),
         ), false);
 
         $token = $manager->authenticate($this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface'));

--- a/tests/Symfony/Tests/Component/Security/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -41,7 +41,7 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
                      ->will($this->throwException($this->getMock('Symfony\Component\Security\Exception\UsernameNotFoundException', null, array(), '', false)))
         ;
 
-        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), 'key', $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
         $method = new \ReflectionMethod($provider, 'retrieveUser');
         $method->setAccessible(true);
 
@@ -59,7 +59,7 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
                      ->will($this->throwException($this->getMock('RuntimeException', null, array(), '', false)))
         ;
 
-        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), 'key', $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
         $method = new \ReflectionMethod($provider, 'retrieveUser');
         $method->setAccessible(true);
 
@@ -80,7 +80,7 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
               ->will($this->returnValue($user))
         ;
 
-        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), 'key', $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
         $reflection = new \ReflectionMethod($provider, 'retrieveUser');
         $reflection->setAccessible(true);
         $result = $reflection->invoke($provider, null, $token);
@@ -98,7 +98,7 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
                      ->will($this->returnValue($user))
         ;
 
-        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface'), 'key', $this->getMock('Symfony\Component\Security\Encoder\EncoderFactoryInterface'));
         $method = new \ReflectionMethod($provider, 'retrieveUser');
         $method->setAccessible(true);
 
@@ -223,7 +223,14 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function getSupportedToken()
     {
-        return $this->getMock('Symfony\Component\Security\Authentication\Token\UsernamePasswordToken', array('getCredentials', 'getUser'), array(), '', false);
+        $mock = $this->getMock('Symfony\Component\Security\Authentication\Token\UsernamePasswordToken', array('getCredentials', 'getUser'), array(), '', false);
+        $mock
+            ->expects($this->any())
+            ->method('getProviderKey')
+            ->will($this->returnValue('key'))
+        ;
+
+        return $mock;
     }
 
     protected function getProvider($user = false, $userChecker = false, $passwordEncoder = null)
@@ -251,6 +258,6 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($passwordEncoder))
         ;
 
-        return new DaoAuthenticationProvider($userProvider, $userChecker, $encoderFactory);
+        return new DaoAuthenticationProvider($userProvider, $userChecker, 'key', $encoderFactory);
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -20,6 +20,17 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
 
         $this->assertTrue($provider->supports($this->getSupportedToken()));
         $this->assertFalse($provider->supports($this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface')));
+
+        $token = $this->getMockBuilder('Symfony\Component\Security\Authentication\Token\PreAuthenticatedToken')
+                    ->disableOriginalConstructor()
+                    ->getMock()
+        ;
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->will($this->returnValue('foo'))
+        ;
+        $this->assertFalse($provider->supports($token));
     }
 
     public function testAuthenticateWhenTokenIsNotSupported()
@@ -70,7 +81,7 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
 
     protected function getSupportedToken($user = false, $credentials = false)
     {
-        $token = $this->getMock('Symfony\Component\Security\Authentication\Token\PreAuthenticatedToken', array('getUser', 'getCredentials'), array(), '', false);
+        $token = $this->getMock('Symfony\Component\Security\Authentication\Token\PreAuthenticatedToken', array('getUser', 'getCredentials', 'getProviderKey'), array(), '', false);
         if (false !== $user) {
             $token->expects($this->once())
                   ->method('getUser')
@@ -83,6 +94,12 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
                   ->will($this->returnValue($credentials))
             ;
         }
+
+        $token
+            ->expects($this->any())
+            ->method('getProviderKey')
+            ->will($this->returnValue('key'))
+        ;
 
         return $token;
     }
@@ -101,6 +118,6 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
             $userChecker = $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface');
         }
 
-        return new PreAuthenticatedAuthenticationProvider($userProvider, $userChecker);
+        return new PreAuthenticatedAuthenticationProvider($userProvider, $userChecker, 'key');
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -160,7 +160,14 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function getSupportedToken()
     {
-        return $this->getMock('Symfony\Component\Security\Authentication\Token\UsernamePasswordToken', array('getCredentials'), array(), '', false);
+        $mock = $this->getMock('Symfony\Component\Security\Authentication\Token\UsernamePasswordToken', array('getCredentials', 'getProviderKey'), array(), '', false);
+        $mock
+            ->expects($this->any())
+            ->method('getProviderKey')
+            ->will($this->returnValue('key'))
+        ;
+
+        return $mock;
     }
 
     protected function getProvider($userChecker = false, $hide = true)
@@ -169,6 +176,6 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
             $userChecker = $this->getMock('Symfony\Component\Security\User\AccountCheckerInterface');
         }
 
-        return $this->getMockForAbstractClass('Symfony\Component\Security\Authentication\Provider\UserAuthenticationProvider', array($userChecker, $hide));
+        return $this->getMockForAbstractClass('Symfony\Component\Security\Authentication\Provider\UserAuthenticationProvider', array($userChecker, 'key', $hide));
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Authentication/Token/PreAuthenticatedTokenTest.php
+++ b/tests/Symfony/Tests/Component/Security/Authentication/Token/PreAuthenticatedTokenTest.php
@@ -17,29 +17,30 @@ class PreAuthenticatedTokenTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
     {
-        $token = new PreAuthenticatedToken('foo', 'bar');
+        $token = new PreAuthenticatedToken('foo', 'bar', 'key');
         $this->assertFalse($token->isAuthenticated());
 
-        $token = new PreAuthenticatedToken('foo', 'bar', array('ROLE_FOO'));
+        $token = new PreAuthenticatedToken('foo', 'bar', 'key', array('ROLE_FOO'));
         $this->assertTrue($token->isAuthenticated());
         $this->assertEquals(array(new Role('ROLE_FOO')), $token->getRoles());
+        $this->assertEquals('key', $token->getProviderKey());
     }
 
     public function testGetCredentials()
     {
-        $token = new PreAuthenticatedToken('foo', 'bar');
+        $token = new PreAuthenticatedToken('foo', 'bar', 'key');
         $this->assertEquals('bar', $token->getCredentials());
     }
 
     public function testGetUser()
     {
-        $token = new PreAuthenticatedToken('foo', 'bar');
+        $token = new PreAuthenticatedToken('foo', 'bar', 'key');
         $this->assertEquals('foo', $token->getUser());
     }
 
     public function testEraseCredentials()
     {
-        $token = new PreAuthenticatedToken('foo', 'bar');
+        $token = new PreAuthenticatedToken('foo', 'bar', 'key');
         $token->eraseCredentials();
         $this->assertEquals('', $token->getCredentials());
     }

--- a/tests/Symfony/Tests/Component/Security/Authentication/Token/UsernamePasswordTokenTest.php
+++ b/tests/Symfony/Tests/Component/Security/Authentication/Token/UsernamePasswordTokenTest.php
@@ -17,12 +17,13 @@ class UsernamePasswordTokenTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
     {
-        $token = new UsernamePasswordToken('foo', 'bar');
+        $token = new UsernamePasswordToken('foo', 'bar', 'key');
         $this->assertFalse($token->isAuthenticated());
 
-        $token = new UsernamePasswordToken('foo', 'bar', array('ROLE_FOO'));
+        $token = new UsernamePasswordToken('foo', 'bar', 'key', array('ROLE_FOO'));
         $this->assertEquals(array(new Role('ROLE_FOO')), $token->getRoles());
         $this->assertTrue($token->isAuthenticated());
+        $this->assertEquals('key', $token->getProviderKey());
     }
 
     /**
@@ -30,20 +31,20 @@ class UsernamePasswordTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetAuthenticatedToTrue()
     {
-        $token = new UsernamePasswordToken('foo', 'bar');
+        $token = new UsernamePasswordToken('foo', 'bar', 'key');
         $token->setAuthenticated(true);
     }
 
     public function testSetAuthenticatedToFalse()
     {
-        $token = new UsernamePasswordToken('foo', 'bar');
+        $token = new UsernamePasswordToken('foo', 'bar', 'key');
         $token->setAuthenticated(false);
         $this->assertFalse($token->isAuthenticated());
     }
 
     public function testEraseCredentials()
     {
-        $token = new UsernamePasswordToken('foo', 'bar');
+        $token = new UsernamePasswordToken('foo', 'bar', 'key');
         $token->eraseCredentials();
         $this->assertEquals('', $token->getCredentials());
     }

--- a/tests/Symfony/Tests/Component/Security/SecurityContextTest.php
+++ b/tests/Symfony/Tests/Component/Security/SecurityContextTest.php
@@ -10,13 +10,14 @@
 
 namespace Symfony\Tests\Component\Security;
 
+use Symfony\Component\Security\Authentication\AuthenticationProviderManager;
 use Symfony\Component\Security\SecurityContext;
 
 class SecurityContextTest extends \PHPUnit_Framework_TestCase
 {
     public function testIsAuthenticated()
     {
-        $context = new SecurityContext();
+        $context = new SecurityContext($this->getMock('Symfony\Component\Security\Authentication\AuthenticationManagerInterface'));
 
         $this->assertFalse($context->isAuthenticated());
 
@@ -33,7 +34,7 @@ class SecurityContextTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUser()
     {
-        $context = new SecurityContext();
+        $context = new SecurityContext($this->getMock('Symfony\Component\Security\Authentication\AuthenticationManagerInterface'));
 
         $this->assertNull($context->getUser());
 
@@ -43,33 +44,64 @@ class SecurityContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $context->getUser());
     }
 
+    public function testVoteAuthenticatesTokenIfNecessary()
+    {
+        $authManager = $this->getMock('Symfony\Component\Security\Authentication\AuthenticationManagerInterface');
+        $decisionManager = $this->getMock('Symfony\Component\Security\Authorization\AccessDecisionManagerInterface');
+
+        $context = new SecurityContext($authManager, $decisionManager);
+        $context->setToken($token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface'));
+
+        $authManager
+            ->expects($this->once())
+            ->method('authenticate')
+            ->with($this->equalTo($token))
+            ->will($this->returnValue($newToken = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface')))
+        ;
+
+        $decisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->will($this->returnValue(true))
+        ;
+
+        $this->assertTrue($context->vote('foo'));
+        $this->assertSame($newToken, $context->getToken());
+    }
+
     public function testVote()
     {
-        $context = new SecurityContext();
-
+        $context = new SecurityContext($this->getMock('Symfony\Component\Security\Authentication\AuthenticationManagerInterface'));
         $this->assertFalse($context->vote('ROLE_FOO'));
-
         $context->setToken($token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface'));
         $this->assertFalse($context->vote('ROLE_FOO'));
 
-        $manager = $this->getMock('Symfony\Component\Security\Authorization\AccessDecisionManager');
+        $manager = $this->getMock('Symfony\Component\Security\Authorization\AccessDecisionManagerInterface');
         $manager->expects($this->once())->method('decide')->will($this->returnValue(false));
-        $context = new SecurityContext($manager);
+        $context = new SecurityContext($this->getMock('Symfony\Component\Security\Authentication\AuthenticationManagerInterface'), $manager);
         $context->setToken($token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface'));
-
+        $token
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->will($this->returnValue(true))
+        ;
         $this->assertFalse($context->vote('ROLE_FOO'));
 
-        $manager = $this->getMock('Symfony\Component\Security\Authorization\AccessDecisionManager');
+        $manager = $this->getMock('Symfony\Component\Security\Authorization\AccessDecisionManagerInterface');
         $manager->expects($this->once())->method('decide')->will($this->returnValue(true));
-        $context = new SecurityContext($manager);
+        $context = new SecurityContext($this->getMock('Symfony\Component\Security\Authentication\AuthenticationManagerInterface'), $manager);
         $context->setToken($token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface'));
-
+        $token
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->will($this->returnValue(true))
+        ;
         $this->assertTrue($context->vote('ROLE_FOO'));
     }
 
     public function testGetSetToken()
     {
-        $context = new SecurityContext();
+        $context = new SecurityContext($this->getMock('Symfony\Component\Security\Authentication\AuthenticationManagerInterface'));
         $this->assertNull($context->getToken());
 
         $context->setToken($token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface'));

--- a/tests/Symfony/Tests/Component/Security/User/UserTest.php
+++ b/tests/Symfony/Tests/Component/Security/User/UserTest.php
@@ -120,7 +120,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
     {
         $user = new User('fabien', 'superpass');
         $user->eraseCredentials();
-        $this->assertNull($user->getPassword());
+        $this->assertEquals('superpass', $user->getPassword());
     }
 
     /**


### PR DESCRIPTION
The initial goal was to fix a security vulnerability in the SecurityContext::vote() implementation since it does not check whether the Token is authenticated, or not. As you can see, this wasn't so easy and I had to touch some more files. The main changes are:
- Tokens which have different authentication providers in different firewalls share now a provider key with their authentication provider, so they are always authenticated against the same provider
- there is only one global authentication manager which contains authentication providers from all firewalls
- SecurityContext::vote checks the authentication status, and re-authenticates the token if necessary, or always if that's configured
