### PR TITLE
No format magic

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameConverter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameConverter.php
@@ -35,6 +35,25 @@ class TemplateNameConverter
     }
 
     /**
+     * Merges the default options with the given set of options.
+     *
+     * @param array $options An array of options
+     * @param array $defaults An array of default options
+     *
+     * @return array The merged set of options
+     */
+    protected function mergeDefaultOptions(array $options, array $defaults = array())
+    {
+        return array_replace(
+            array(
+                 'format' => '',
+            ),
+            $defaults,
+            $options
+        );
+    }
+
+    /**
      * Converts a short template notation to a template name and an array of options.
      *
      * @param string $name     A short template template
@@ -49,31 +68,20 @@ class TemplateNameConverter
             throw new \InvalidArgumentException(sprintf('Template name "%s" is not valid.', $name));
         }
 
-        $options = array_replace(
-            array(
-                'format' => '',
-            ),
-            $defaults,
-            array(
-                'bundle'     => str_replace('\\', '/', $parts[0]),
-                'controller' => $parts[1],
-            )
+        $options = array(
+            'bundle'     => str_replace('\\', '/', $parts[0]),
+            'controller' => $parts[1],
         );
+        $options = $this->mergeDefaultOptions($options, $defaults);
 
         $elements = explode('.', $parts[2]);
         if (3 === count($elements)) {
             $parts[2] = $elements[0];
-            if ('html' !== $elements[1]) {
-                $options['format'] = '.'.$elements[1];
-            }
+            $options['format'] = '.'.$elements[1];
             $options['renderer'] = $elements[2];
         } elseif (2 === count($elements)) {
             $parts[2] = $elements[0];
             $options['renderer'] = $elements[1];
-            $format = $this->container->get('request')->getRequestFormat();
-            if (null !== $format && 'html' !== $format) {
-                $options['format'] = '.'.$format;
-            }
         } else {
             throw new \InvalidArgumentException(sprintf('Template name "%s" is not valid.', $name));
         }


### PR DESCRIPTION
This removes the magic handling for template lookups based on _format. Effectively this mean if you use "index.twig" in your controller it will look for "index.twig". After all the mantra for Symfony2 is no magic, so we should be cautious about any magic we do deliver and this seems like more trouble than its worth.

Especially since if you want the old behavior you can get it more or less (you cannot omit 'html' in the template name in the file system anymore) with the following:
        $this->render('FooBundle:Default:index.'.$this->request->getRequestFormat().'.twig);
