### PR TITLE
No format magic and array tpl ids

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameConverter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameConverter.php
@@ -56,13 +56,23 @@ class TemplateNameConverter
     /**
      * Converts a short template notation to a template name and an array of options.
      *
-     * @param string $name     A short template template
-     * @param array  $defaults An array of default options
+     * @param string|array  $name     A short template template
+     * @param array         $defaults An array of default options
      *
      * @return array An array composed of the template name and an array of options
      */
     public function fromShortNotation($name, array $defaults = array())
     {
+        if (is_array($name)) {
+            $options = $this->mergeDefaultOptions($name, $defaults);
+
+            if (empty($name['name'])) {
+                throw new \InvalidArgumentException(sprintf('Template name "%s" is not valid.', var_export($name, true)));
+            }
+
+            return array($name['name'], $options);
+        }
+
         $parts = explode(':', $name);
         if (3 !== count($parts)) {
             throw new \InvalidArgumentException(sprintf('Template name "%s" is not valid.', $name));


### PR DESCRIPTION
This pull builds on https://github.com/fabpot/symfony/pull/390 mainly for convenience. There might be a need to add some more defaults to `mergeDefaultOptions()`, but the basic idea is that since we need to parse the template identifier anyway, why not let the user pass the template identifier as an array to begin with. This can make it easier to construct template identifiers.

For example some people seem to use twig for HTML, and php renderer for everything else. Others might want to default template names to always the current bundle/controller. 
