### PR TITLE
Separate security contexts

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -162,6 +162,7 @@
         <service id="security.context_listener" class="%security.context_listener.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="collection"></argument>
+            <argument />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
     </services>

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/ContextListener.php
@@ -32,13 +32,19 @@ use Symfony\Component\Security\User\AccountInterface;
 class ContextListener implements ListenerInterface
 {
     protected $context;
+    protected $contextKey;
     protected $logger;
     protected $userProviders;
 
-    public function __construct(SecurityContext $context, array $userProviders, LoggerInterface $logger = null)
+    public function __construct(SecurityContext $context, array $userProviders, $contextKey, LoggerInterface $logger = null)
     {
+        if (empty($contextKey)) {
+            throw new \InvalidArgumentException('$contextKey must not be empty.');
+        }
+
         $this->context = $context;
         $this->userProviders = $userProviders;
+        $this->contextKey = $contextKey;
         $this->logger = $logger;
     }
 
@@ -74,7 +80,7 @@ class ContextListener implements ListenerInterface
 
         $session = $request->hasSession() ? $request->getSession() : null;
 
-        if (null === $session || null === $token = $session->get('_security')) {
+        if (null === $session || null === $token = $session->get('_security_'.$this->contextKey)) {
             $this->context->setToken(null);
         } else {
             if (null !== $this->logger) {
@@ -114,7 +120,7 @@ class ContextListener implements ListenerInterface
             $this->logger->debug('Write SecurityContext in the session');
         }
 
-        $event->get('request')->getSession()->set('_security', serialize($token));
+        $event->get('request')->getSession()->set('_security_'.$this->contextKey, serialize($token));
 
         return $response;
     }


### PR DESCRIPTION
This pull request eliminates another likely attack vector. This will only affect people which have multiple firewalls. Exploitable configurations could look like this:

```
firewalls:
    backend:
        pattern: /admin/.*
        form-login:
            provider: not_default_provider
            login_path: /admin/login
            check_path: /admin/login-check
        logout: true
    main:
        pattern: /.*
        form-login:
            login_path: /login
            check_path: /login-check
        logout: true
        anonymous: true
```

In this case, users which authenticated through the "main" firewall are also considered authenticated by the "backend" firewall even if it uses a different user provider. With this patch, both firewalls will have separate security contexts, but it's still possible to achieve the old behavior if you change your config to:

```
firewalls:
    backend:
        pattern: /admin/.*
        context: default
        form-login:
            provider: not_default_provider
            login_path: /admin/login
            check_path: /admin/login-check
        logout: true
    main:
        pattern: /.*
        context: default
        form-login:
            login_path: /login
            check_path: /login-check
        logout: true
        anonymous: true
```
