### PR TITLE
Fix typo in framework bundle services definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -10,7 +10,7 @@
         <parameter key="response.class">Symfony\Component\HttpFoundation\Response</parameter>
         <parameter key="error_handler.class">Symfony\Component\HttpKernel\Debug\ErrorHandler</parameter>
         <parameter key="error_handler.level">null</parameter>
-        <parameter key="filesystem.class">Symfony\Bundle\FrameworkBundle\Util\FileSystem</parameter>
+        <parameter key="filesystem.class">Symfony\Bundle\FrameworkBundle\Util\Filesystem</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
It does not work in case sensitive filesystems as the class is named Filesystem and not FileSystem.
