### PR TITLE
Addition of PHP form "row" helper

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_group.php.html
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_group.php.html
@@ -2,7 +2,7 @@
 
 <div>
     <?php foreach ($field->getVisibleFields() as $child): ?>
-        <?php echo $view['form']->render($child, array(), array(), 'FrameworkBundle:Form:field_row.php.html') ?>
+        <?php echo $view['form']->row($child) ?>
     <?php endforeach; ?>
 </div>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -106,6 +106,21 @@ class FormHelper extends Helper
         )));
     }
 
+    /**
+     * Renders the entire form field "row".
+     *
+     * @param  FieldInterface $field
+     * @return string
+     */
+    public function row(/*FieldInterface*/ $field)
+    {
+        $template = 'FrameworkBundle:Form:field_row.php.html';
+
+        return $this->engine->render($template, array(
+            'field' => $field,
+        ));
+    }
+
     public function label(/*FieldInterface */$field, $label = false, array $parameters = array(), $template = null)
     {
         if (null === $template) {


### PR DESCRIPTION
Hey Fabien-

I think this is just an oversight as it appears no PHP equivalent to Twig's form_row() function exists. This helps round out the feature and its documentation.

I also think that both "row" functions should accept an array of attributes as arg1 and the label name as arg2. I'll try that as a future pull request.

Thanks!
