### PR TITLE
Generate entities

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -66,8 +66,9 @@ EOT
 
             // retrieve the full bundle classname
             $class = $bundle->getReflection()->getName();
+            $namespace = $bundle->getReflection()->getNamespaceName();
 
-            if ($filterBundle && $filterBundle != $class) {
+            if ($filterBundle && $filterBundle != $namespace) {
                 continue;
             }
 


### PR DESCRIPTION
This commit fixes the `doctrine:generate:entities` command when using the `--bundle` option. This option contains a bundle namespace, not a class name (see the way the entity option is used with it).
