### PR TITLE
Acl fix

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
@@ -585,7 +585,7 @@ class SecurityExtension extends Extension
         }
 
         if (isset($config['connection'])) {
-            $container->setAlias(sprintf('doctrine.dbal.%s_connection', $config['connection']), 'security.acl.dbal.connection');
+            $container->setAlias('security.acl.dbal.connection', sprintf('doctrine.dbal.%s_connection', $config['connection']));
         }
 
         if (isset($config['cache'])) {


### PR DESCRIPTION
This fixes the alias for the connection which was set the wrong way, overwriting the DBAL connection and creating an infinite loop when using the `default` connection
