### PR TITLE
Making access denied handling easier customizable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -67,6 +67,9 @@
         <parameter key="security.access.decision_manager.allow_if_all_abstain">false</parameter>
         <parameter key="security.access.decision_manager.allow_if_equal_granted_denied">true</parameter>
         
+        <parameter key="security.access.denied_handler.class">Symfony\Component\HttpKernel\Security\ExceptionTranslation\AccessDeniedHandler</parameter>
+        <parameter key="security.access.denied_url">/access-denied</parameter>
+        
         <parameter key="security.access.simple_role_voter.class">Symfony\Component\Security\Authorization\Voter\RoleVoter</parameter>
         <parameter key="security.access.authenticated_voter.class">Symfony\Component\Security\Authorization\Voter\AuthenticatedVoter</parameter>
         <parameter key="security.access.role_hierarchy_voter.class">Symfony\Component\Security\Authorization\Voter\RoleHierarchyVoter</parameter>
@@ -152,6 +155,10 @@
         <service id="security.access.role_hierarchy_voter" class="%security.access.role_hierarchy_voter.class%" public="false">
             <argument type="service" id="security.role_hierarchy" />
         </service>
+        
+        <service id="security.access.denied_handler" class="%security.access.denied_handler.class%" public="false">
+            <argument>%security.access.denied_url%</argument>
+        </service>        
 
         <service id="security.firewall" class="%security.firewall.class%" public="false">
             <tag name="kernel.listener" priority="-128" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
@@ -64,9 +64,10 @@
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.trust_resolver" />
             <argument type="service" id="security.authentication.entry_point" on-invalid="null" />
-            <argument>%security.access_denied.url%</argument>
+            <argument type="service" id="security.access.denied_handler" on-invalid="null" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
+
 
         <service id="security.authentication.switchuser_listener" class="%security.authentication.switchuser_listener.class%" public="false">
             <argument type="service" id="security.context" />

--- a/src/Symfony/Component/HttpKernel/Security/ExceptionTranslation/AccessDeniedHandler.php
+++ b/src/Symfony/Component/HttpKernel/Security/ExceptionTranslation/AccessDeniedHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Security\ExceptionTranslation;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Security\SecurityContext;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\Request;
+
+class AccessDeniedHandler implements AccessDeniedHandlerInterface
+{
+    protected $errorPage;
+
+    public function __construct($errorPage = null)
+    {
+        $this->errorPage = $errorPage;
+    }
+
+    public function handle(Event $event, Request $request, AccessDeniedException $exception)
+    {
+        if (null === $this->errorPage) {
+            return;
+        }
+
+        $subRequest = Request::create($this->errorPage);
+        $subRequest->attributes->set(SecurityContext::ACCESS_DENIED_ERROR, $exception->getMessage());
+
+        $response = $event->getSubject()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
+        $response->setStatusCode(403);
+
+        return $response;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Security/ExceptionTranslation/AccessDeniedHandlerInterface.php
+++ b/src/Symfony/Component/HttpKernel/Security/ExceptionTranslation/AccessDeniedHandlerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Security\ExceptionTranslation;
+
+use Symfony\Component\HttpFoundation\Request;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Security\Exception\AccessDeniedException;
+
+/**
+ * This is used by the ExceptionListener to translate an AccessDeniedException
+ * to a Response object.
+ *
+ * @author Johannes M. Schmit <schmittjoh@gmail.com>
+ */
+interface AccessDeniedHandlerInterface
+{
+    /**
+     * Handles an access denied failure.
+     *
+     * @param Event $event
+     * @param Request $request
+     * @param AccessDeniedException $accessDeniedException
+     *
+     * @return Response may return null
+     */
+    function handle(Event $event, Request $request, AccessDeniedException $accessDeniedException);
+}


### PR DESCRIPTION
This makes the access denied handling easily customizable without overwriting the entire listener. New configuration options look as follows:

```
security.config:
    # global default
    access-denied-url: /foo

    firewalls:
        default:
            # overwrites global for this firewall (other firewalls still use the global default)
            access-denied-url: /bar

            # alternatively, an own AccessDeniedHandlerInterface implementation
            access-denied-handler: some.service.id
```
