### PR TITLE
Fix render tag parsing

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TokenParser/RenderTokenParser.php
+++ b/src/Symfony/Bundle/TwigBundle/TokenParser/RenderTokenParser.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\TwigBundle\TokenParser;
 use Symfony\Bundle\TwigBundle\Node\RenderNode;
 
 /**
- * 
+ *
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  */
@@ -35,13 +35,15 @@ class RenderTokenParser extends \Twig_TokenParser
         if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'with')) {
             $this->parser->getStream()->next();
 
+            $hasAttributes = true;
             $attributes = $this->parser->getExpressionParser()->parseExpression();
         } else {
+            $hasAttributes = false;
             $attributes = new \Twig_Node_Expression_Array(array(), $token->getLine());
         }
 
         // options
-        if ($this->parser->getStream()->test(\Twig_Token::PUNCTUATION_TYPE, ',')) {
+        if ($hasAttributes && $this->parser->getStream()->test(\Twig_Token::PUNCTUATION_TYPE, ',')) {
             $this->parser->getStream()->next();
 
             $options = $this->parser->getExpressionParser()->parseExpression();


### PR DESCRIPTION
essentially it fixes the following, he misinterpreted the docs or what do I know, but his error was totally not related to the template syntax error, which is bad.

```
16:28 <rande> Controller "…." requires that you provide a value for the "$code" argument
[..]
16:30 <rande>  {% render 'SonataBaseApplicationBundle:Core:getShortObjectDescription', {
16:30 <rande>                             'code': field_description.associationadmin.code,
16:30 <rande>                             'object_id': value.id
16:30 <rande>                         }%}
```
