### PR TITLE
Load config once

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -29,6 +29,20 @@ use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineEx
  */
 class DoctrineExtension extends AbstractDoctrineExtension
 {
+    public function dbalLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doDbalLoad($config, $container);
+        }
+    }
+
+    public function ormLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doOrmLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the DBAL configuration.
      *
@@ -39,7 +53,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      * @param array $config An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function dbalLoad($config, ContainerBuilder $container)
+    protected function doDbalLoad($config, ContainerBuilder $container)
     {
         $this->loadDbalDefaults($config, $container);
         $this->loadDbalConnections($config, $container);
@@ -55,7 +69,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      * @param array $config An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function ormLoad($config, ContainerBuilder $container)
+    protected function doOrmLoad($config, ContainerBuilder $container)
     {
         $this->loadOrmDefaults($config, $container);
         $this->loadOrmEntityManagers($config, $container);

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/ContainerTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/ContainerTest.php
@@ -26,7 +26,7 @@ class ContainerTest extends TestCase
         )));
         $loader = new DoctrineExtension();
         $container->registerExtension($loader);
-        $loader->dbalLoad(array(
+        $loader->dbalLoad(array(array(
             'connections' => array(
                 'default' => array(
                     'driver' => 'pdo_mysql',
@@ -34,7 +34,7 @@ class ContainerTest extends TestCase
                     'platform-service' => 'my.platform',
                 )
             )
-        ), $container);
+        )), $container);
         $loader->ormLoad(array('bundles' => array('YamlBundle' => array())), $container);
 
         $container->setDefinition('my.platform', new \Symfony\Component\DependencyInjection\Definition('Doctrine\DBAL\Platforms\MySqlPlatform'));

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -28,19 +28,19 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
+        $loader->dbalLoad(array(array()), $container);
         $this->assertEquals('Symfony\\Bundle\\DoctrineBundle\\DataCollector\\DoctrineDataCollector', $container->getParameter('doctrine.data_collector.class'), '->dbalLoad() loads the dbal.xml file if not already loaded');
 
         // doctrine.dbal.default_connection
         $this->assertEquals('default', $container->getParameter('doctrine.dbal.default_connection'), '->dbalLoad() overrides existing configuration options');
-        $loader->dbalLoad(array('default_connection' => 'foo'), $container);
+        $loader->dbalLoad(array(array('default_connection' => 'foo')), $container);
         $this->assertEquals('foo', $container->getParameter('doctrine.dbal.default_connection'), '->dbalLoad() overrides existing configuration options');
-        $loader->dbalLoad(array(), $container);
+        $loader->dbalLoad(array(array()), $container);
         $this->assertEquals('foo', $container->getParameter('doctrine.dbal.default_connection'), '->dbalLoad() overrides existing configuration options');
 
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
-        $loader->dbalLoad(array('password' => 'foo'), $container);
+        $loader->dbalLoad(array(array('password' => 'foo')), $container);
 
         $arguments = $container->getDefinition('doctrine.dbal.default_connection')->getArguments();
         $config = $arguments[0];
@@ -48,7 +48,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('foo', $config['password']);
         $this->assertEquals('root', $config['user']);
 
-        $loader->dbalLoad(array('user' => 'foo'), $container);
+        $loader->dbalLoad(array(array('user' => 'foo')), $container);
         $this->assertEquals('foo', $config['password']);
         $this->assertEquals('root', $config['user']);
     }
@@ -61,7 +61,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $loadXml = new XmlFileLoader($container, __DIR__.'/Fixtures/config/xml');
         $loadXml->load('dbal_service_multiple_connections.xml');
-        $loader->dbalLoad(array(), $container);
+        $loader->dbalLoad(array(array()), $container);
 
         $container->getCompilerPassConfig()->setOptimizationPasses(array());
         $container->getCompilerPassConfig()->setRemovingPasses(array());
@@ -95,7 +95,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $loadXml = new XmlFileLoader($container, __DIR__.'/Fixtures/config/xml');
         $loadXml->load('dbal_service_single_connection.xml');
-        $loader->dbalLoad(array(), $container);
+        $loader->dbalLoad(array(array()), $container);
 
         $container->getCompilerPassConfig()->setOptimizationPasses(array());
         $container->getCompilerPassConfig()->setRemovingPasses(array());
@@ -116,8 +116,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array('mappings' => array('YamlBundle' => array())), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array('mappings' => array('YamlBundle' => array()))), $container);
 
         $this->assertEquals('Doctrine\DBAL\Connection', $container->getParameter('doctrine.dbal.connection_class'));
         $this->assertEquals('Doctrine\ORM\Configuration', $container->getParameter('doctrine.orm.configuration_class'));
@@ -144,8 +144,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
             'mappings' => array('YamlBundle' => array()),
         );
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad($config, $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array($config), $container);
 
         $this->assertEquals('MyProxies', $container->getParameter('doctrine.orm.proxy_namespace'));
         $this->assertEquals(true, $container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
@@ -193,8 +193,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array(), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array()), $container);
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
         $this->assertEquals('Doctrine\DBAL\DriverManager', $definition->getClass());
@@ -215,8 +215,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $loader = new DoctrineExtension();
         $container->registerExtension($loader);
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array(), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array()), $container);
 
         $this->loadFromFile($container, 'orm_service_simple_single_entity_manager');
 
@@ -358,8 +358,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array('mappings' => array('YamlBundle' => array())), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array('mappings' => array('YamlBundle' => array()))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
@@ -372,8 +372,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array('mappings' => array('YamlBundle' => array('alias' => 'yml'))), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array('mappings' => array('YamlBundle' => array('alias' => 'yml')))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
@@ -386,8 +386,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('YamlBundle');
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array('mappings' => array('YamlBundle' => array())), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array('mappings' => array('YamlBundle' => array()))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -401,8 +401,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('XmlBundle');
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array('mappings' => array('XmlBundle' => array())), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array('mappings' => array('XmlBundle' => array()))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -416,8 +416,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle');
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array('mappings' => array('AnnotationsBundle' => array())), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array('mappings' => array('AnnotationsBundle' => array()))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -431,15 +431,15 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer(array('XmlBundle', 'AnnotationsBundle'));
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array(
-            'auto_generate_proxy_dir' => true,
-            'mappings' => array('AnnotationsBundle' => array())
-        ), $container);
-        $loader->ormLoad(array(
-            'auto_generate_proxy_dir' => false,
-            'mappings' => array('XmlBundle' => array())
-        ), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array(
+                'auto_generate_proxy_dir' => true,
+                'mappings' => array('AnnotationsBundle' => array())
+            ),
+            array(
+                'auto_generate_proxy_dir' => false,
+                'mappings' => array('XmlBundle' => array())
+        )), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', array(
@@ -611,8 +611,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle', 'Vendor');
         $loader = new DoctrineExtension();
 
-        $loader->dbalLoad(array(), $container);
-        $loader->ormLoad(array('mappings' => array('AnnotationsBundle' => array())), $container);
+        $loader->dbalLoad(array(array()), $container);
+        $loader->ormLoad(array(array('mappings' => array('AnnotationsBundle' => array()))), $container);
 
         $calls = $container->getDefinition('doctrine.orm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.orm.default_annotation_metadata_driver', (string) $calls[0][1][0]);

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -29,6 +29,13 @@ use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineEx
  */
 class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 {
+    public function mongodbLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doMongodbLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the MongoDB ODM configuration.
      *
@@ -39,7 +46,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
      * @param array $config An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function mongodbLoad($config, ContainerBuilder $container)
+    protected function doMongodbLoad($config, ContainerBuilder $container)
     {
         $this->loadDefaults($config, $container);
         $this->loadConnections($config, $container);

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -28,7 +28,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->mongodbLoad(array(), $container);
+        $loader->mongodbLoad(array(array()), $container);
 
         $this->assertEquals('Doctrine\MongoDB\Connection', $container->getParameter('doctrine.odm.mongodb.connection_class'));
         $this->assertEquals('Doctrine\ODM\MongoDB\Configuration', $container->getParameter('doctrine.odm.mongodb.configuration_class'));
@@ -55,7 +55,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
             'proxy_namespace' => 'MyProxies',
             'auto_generate_proxy_classes' => true,
         );
-        $loader->mongodbLoad($config, $container);
+        $loader->mongodbLoad(array($config), $container);
 
         $this->assertEquals('MyProxies', $container->getParameter('doctrine.odm.mongodb.proxy_namespace'));
         $this->assertEquals(true, $container->getParameter('doctrine.odm.mongodb.auto_generate_proxy_classes'));
@@ -85,7 +85,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
             'server' => 'mongodb://localhost:27017',
             'options' => array('connect' => true)
         );
-        $loader->mongodbLoad($config, $container);
+        $loader->mongodbLoad(array($config), $container);
 
         $definition = $container->getDefinition('doctrine.odm.mongodb.default_connection');
         $this->assertEquals('%doctrine.odm.mongodb.connection_class%', $definition->getClass());
@@ -215,7 +215,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->mongodbLoad(array('mappings' => array('YamlBundle' => array())), $container);
+        $loader->mongodbLoad(array(array('mappings' => array('YamlBundle' => array()))), $container);
 
         $definition = $container->getDefinition('doctrine.odm.mongodb.default_configuration');
         $calls = $definition->getMethodCalls();
@@ -228,7 +228,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension('YamlBundle');
 
-        $loader->mongodbLoad(array('mappings' => array('YamlBundle' => array())), $container);
+        $loader->mongodbLoad(array(array('mappings' => array('YamlBundle' => array()))), $container);
 
         $calls = $container->getDefinition('doctrine.odm.mongodb.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.odm.mongodb.default_yml_metadata_driver', (string) $calls[0][1][0]);
@@ -240,7 +240,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer('XmlBundle');
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->mongodbLoad(array('mappings' => array('XmlBundle' => array())), $container);
+        $loader->mongodbLoad(array(array('mappings' => array('XmlBundle' => array()))), $container);
 
         $calls = $container->getDefinition('doctrine.odm.mongodb.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.odm.mongodb.default_xml_metadata_driver', (string) $calls[0][1][0]);
@@ -252,7 +252,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle');
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->mongodbLoad(array('mappings' => array('AnnotationsBundle' => array())), $container);
+        $loader->mongodbLoad(array(array('mappings' => array('AnnotationsBundle' => array()))), $container);
 
         $calls = $container->getDefinition('doctrine.odm.mongodb.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.odm.mongodb.default_annotation_metadata_driver', (string) $calls[0][1][0]);
@@ -330,7 +330,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->mongodbLoad(array(), $container);
+        $loader->mongodbLoad(array(array()), $container);
 
         $this->assertEquals(array(
             'Namespace1\\',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -29,13 +29,20 @@ use Symfony\Component\Form\FormContext;
  */
 class FrameworkExtension extends Extension
 {
+    public function configLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doConfigLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the web configuration.
      *
      * @param array            $config    An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function configLoad(array $config, ContainerBuilder $container)
+    protected function doConfigLoad(array $config, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, __DIR__.'/../Resources/config');
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/SecurityExtension.php
@@ -29,13 +29,27 @@ use Symfony\Component\HttpFoundation\RequestMatcher;
  */
 class SecurityExtension extends Extension
 {
+    public function configLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doConfigLoad($config, $container);
+        }
+    }
+
+    public function aclLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doAclLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the web configuration.
      *
      * @param array            $config    An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function configLoad($config, ContainerBuilder $container)
+    protected function doConfigLoad($config, ContainerBuilder $container)
     {
         if (!$container->hasDefinition('security.context')) {
             $loader = new XmlFileLoader($container, array(__DIR__.'/../Resources/config', __DIR__.'/Resources/config'));
@@ -577,7 +591,7 @@ class SecurityExtension extends Extension
         return $switchUserListenerId;
     }
 
-    public function aclLoad(array $config, ContainerBuilder $container)
+    protected function doAclLoad(array $config, ContainerBuilder $container)
     {
         if (!$container->hasDefinition('security.acl')) {
             $loader = new XmlFileLoader($container, array(__DIR__.'/../Resources/config', __DIR__.'/Resources/config'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -23,26 +23,26 @@ class FrameworkExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new FrameworkExtension();
 
-        $loader->configLoad(array(), $container);
+        $loader->configLoad(array(array()), $container);
         $this->assertEquals('Symfony\\Bundle\\FrameworkBundle\\RequestListener', $container->getParameter('request_listener.class'), '->webLoad() loads the web.xml file if not already loaded');
 
         $container = $this->getContainer();
         $loader = new FrameworkExtension();
 
         // profiler
-        $loader->configLoad(array('profiler' => true), $container);
+        $loader->configLoad(array(array('profiler' => true)), $container);
         $this->assertEquals('Symfony\Component\HttpKernel\Profiler\Profiler', $container->getParameter('profiler.class'), '->configLoad() loads the collectors.xml file if not already loaded');
 
         // templating
-        $loader->configLoad(array('templating' => array()), $container);
+        $loader->configLoad(array(array('templating' => array())), $container);
         $this->assertEquals('Symfony\\Bundle\\FrameworkBundle\\Templating\\PhpEngine', $container->getParameter('templating.engine.php.class'), '->templatingLoad() loads the templating.xml file if not already loaded');
 
         // validation
-        $loader->configLoad(array('validation' => array('enabled' => true)), $container);
+        $loader->configLoad(array(array('validation' => array('enabled' => true))), $container);
         $this->assertEquals('Symfony\Component\Validator\Validator', $container->getParameter('validator.class'), '->validationLoad() loads the validation.xml file if not already loaded');
         $this->assertFalse($container->hasDefinition('validator.mapping.loader.annotation_loader'), '->validationLoad() doesn\'t load the annotations service unless its needed');
 
-        $loader->configLoad(array('validation' => array('enabled' => true, 'annotations' => true)), $container);
+        $loader->configLoad(array(array('validation' => array('enabled' => true, 'annotations' => true))), $container);
         $this->assertTrue($container->hasDefinition('validator.mapping.loader.annotation_loader'), '->validationLoad() loads the annotations service');
     }
 

--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -23,6 +23,13 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class SwiftMailerExtension extends Extension
 {
+    public function configLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doConfigLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the Swift Mailer configuration.
      *
@@ -37,7 +44,7 @@ class SwiftMailerExtension extends Extension
      * @param array            $config    An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function configLoad(array $config, ContainerBuilder $container)
+    protected function doConfigLoad(array $config, ContainerBuilder $container)
     {
         if (!$container->hasDefinition('swiftmailer.mailer')) {
             $loader = new XmlFileLoader($container, __DIR__.'/../Resources/config');

--- a/src/Symfony/Bundle/SwiftmailerBundle/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -22,12 +22,12 @@ class SwiftmailerExtensionTest extends TestCase
         $container = new ContainerBuilder();
         $loader = new SwiftmailerExtension();
 
-        $loader->configLoad(array(), $container);
+        $loader->configLoad(array(array()), $container);
         $this->assertEquals('Swift_Mailer', $container->getParameter('swiftmailer.class'), '->mailerLoad() loads the swiftmailer.xml file if not already loaded');
 
-        $loader->configLoad(array('transport' => 'sendmail'), $container);
+        $loader->configLoad(array(array('transport' => 'sendmail')), $container);
         $this->assertEquals('sendmail', $container->getParameter('swiftmailer.transport.name'), '->mailerLoad() overrides existing configuration options');
-        $loader->configLoad(array(), $container);
+        $loader->configLoad(array(array()), $container);
         $this->assertEquals('sendmail', $container->getParameter('swiftmailer.transport.name'), '->mailerLoad() overrides existing configuration options');
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -23,13 +23,20 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class TwigExtension extends Extension
 {
+    public function configLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doConfigLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the Twig configuration.
      *
      * @param array            $config    An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function configLoad(array $config, ContainerBuilder $container)
+    protected function doConfigLoad(array $config, ContainerBuilder $container)
     {
         if (!$container->hasDefinition('twig')) {
             $loader = new XmlFileLoader($container, __DIR__.'/../Resources/config');

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -23,10 +23,10 @@ class TwigExtensionTest extends TestCase
         $container = new ContainerBuilder();
         $loader = new TwigExtension();
 
-        $loader->configLoad(array(), $container);
+        $loader->configLoad(array(array()), $container);
         $this->assertEquals('Twig_Environment', $container->getParameter('twig.class'), '->configLoad() loads the twig.xml file if not already loaded');
 
-        $loader->configLoad(array('charset' => 'ISO-8859-1'), $container);
+        $loader->configLoad(array(array('charset' => 'ISO-8859-1')), $container);
         $options = $container->getParameter('twig.options');
         $this->assertEquals('ISO-8859-1', $options['charset'], '->configLoad() overrides existing configuration options');
         $this->assertEquals('%kernel.debug%', $options['debug'], '->configLoad() merges the new values with the old ones');
@@ -37,10 +37,10 @@ class TwigExtensionTest extends TestCase
         // XML
         $container = new ContainerBuilder();
         $loader = new TwigExtension();
-        $loader->configLoad(array('global' => array(
+        $loader->configLoad(array(array('global' => array(
             array('key' => 'foo', 'type' => 'service', 'id' => 'bar'),
             array('key' => 'pi', 'value' => 3.14),
-        )), $container);
+        ))), $container);
         $config = $container->getDefinition('twig')->getMethodCalls();
         $this->assertEquals('foo', $config[0][1][0]);
         $this->assertEquals(new Reference('bar'), $config[0][1][1]);
@@ -50,10 +50,10 @@ class TwigExtensionTest extends TestCase
         // YAML, PHP
         $container = new ContainerBuilder();
         $loader = new TwigExtension();
-        $loader->configLoad(array('globals' => array(
+        $loader->configLoad(array(array('globals' => array(
             'foo' => '@bar',
             'pi'  => 3.14,
-        )), $container);
+        ))), $container);
         $config = $container->getDefinition('twig')->getMethodCalls();
         $this->assertEquals('foo', $config[0][1][0]);
         $this->assertEquals(new Reference('bar'), $config[0][1][1]);
@@ -67,7 +67,7 @@ class TwigExtensionTest extends TestCase
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass');
         $loader = new TwigExtension();
-        $loader->configLoad(array('extensions' => array(array('id' => 'foo'))), $container);
+        $loader->configLoad(array(array('extensions' => array(array('id' => 'foo')))), $container);
         $config = $container->getDefinition('foo');
         $this->assertEquals(array('twig.extension'), array_keys($config->getTags()));
 
@@ -75,7 +75,7 @@ class TwigExtensionTest extends TestCase
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass');
         $loader = new TwigExtension();
-        $loader->configLoad(array('extensions' => array('foo')), $container);
+        $loader->configLoad(array(array('extensions' => array('foo'))), $container);
         $config = $container->getDefinition('foo');
         $this->assertEquals(array('twig.extension'), array_keys($config->getTags()));
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -32,13 +32,20 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class WebProfilerExtension extends Extension
 {
+    public function configLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doConfigLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the web profiler configuration.
      *
      * @param array            $config    An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function configLoad(array $config, ContainerBuilder $container)
+    protected function doConfigLoad(array $config, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, __DIR__.'/../Resources/config');
 

--- a/src/Symfony/Bundle/ZendBundle/DependencyInjection/ZendExtension.php
+++ b/src/Symfony/Bundle/ZendBundle/DependencyInjection/ZendExtension.php
@@ -22,6 +22,13 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class ZendExtension extends Extension
 {
+    public function configLoad(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            $this->doConfigLoad($config, $container);
+        }
+    }
+
     /**
      * Loads the Zend Framework configuration.
      *
@@ -34,7 +41,7 @@ class ZendExtension extends Extension
      * @param array            $config    An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    public function configLoad($config, ContainerBuilder $container)
+    protected function doConfigLoad($config, ContainerBuilder $container)
     {
         if (isset($config['logger'])) {
             $this->registerLoggerConfiguration($config, $container);

--- a/src/Symfony/Bundle/ZendBundle/Tests/DependencyInjection/ZendExtensionTest.php
+++ b/src/Symfony/Bundle/ZendBundle/Tests/DependencyInjection/ZendExtensionTest.php
@@ -23,10 +23,10 @@ class ZendExtensionTest extends TestCase
         $container = new ContainerBuilder();
         $loader = new ZendExtension();
 
-        $loader->configLoad(array('logger' => array()), $container);
+        $loader->configLoad(array(array('logger' => array())), $container);
         $this->assertEquals('Symfony\\Bundle\\ZendBundle\\Logger\\Logger', $container->getParameter('zend.logger.class'), '->loggerLoad() loads the logger.xml file if not already loaded');
 
-        $loader->configLoad(array('logger' => array('priority' => 3)), $container);
+        $loader->configLoad(array(array('logger' => array('priority' => 3))), $container);
         $this->assertEquals(3, $container->getParameter('zend.logger.priority'), '->loggerLoad() overrides existing configuration options');
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -36,9 +36,8 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
 
             $tmpContainer = new ContainerBuilder($container->getParameterBag());
             $tmpContainer->addObjectResource($extension);
-            foreach ($configs as $config) {
-                $extension->load($tag, $config, $tmpContainer);
-            }
+
+            $extension->load($tag, $configs, $tmpContainer);
 
             $container->merge($tmpContainer);
         }


### PR DESCRIPTION
This is a first step to make the merging process easier as discussed in one of the last IRC meetings.

It only shifts the iteration over the config sections from the merge pass to the xxxLoad methods. The behavior of the extensions remains unchanged. After applying this pull request, we can then get people familiar with the respective core extension to implement some merging logic.

Since we are breaking BC with all extensions out there, what do you think about renaming the xxxLoad methods to loadXXX instead? So far, the feedback on this seems to be unanimously positive, see

http://groups.google.com/group/symfony-devs/browse_thread/thread/1eb1cf8ef08b5f6a/0f2330a0e530010c?#0f2330a0e530010c (last 3 posts)
