### PR TITLE
File locator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -25,6 +25,9 @@
 
         <service id="routing.file_locator" class="%routing.file_locator.class%" public="false">
             <argument type="service" id="kernel" />
+            <argument type="collection">
+                <argument>%kernel.root_dir%/config/</argument>
+            </argument>
         </service>
 
         <service id="routing.loader.xml" class="%routing.loader.xml.class%" public="false">


### PR DESCRIPTION
this allows to import the `app/config/routing.yml` file in `app/config/routing_dev.yml` as we cannot give it an absolute path there.
With this fix it is now possible to import it using `resources: routing.yml` which was also possible before the refactoring.
