### PR TITLE
Performance tweaks

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -76,7 +76,8 @@
         <parameter key="security.exception_listener.class">Symfony\Component\HttpKernel\Security\Firewall\ExceptionListener</parameter>
         <parameter key="security.context_listener.class">Symfony\Component\HttpKernel\Security\Firewall\ContextListener</parameter>
         <parameter key="security.firewall.class">Symfony\Component\HttpKernel\Security\Firewall</parameter>
-        <parameter key="security.firewall.map.class">Symfony\Component\HttpKernel\Security\FirewallMap</parameter>
+        <parameter key="security.firewall.map.class">Symfony\Bundle\FrameworkBundle\Security\FirewallMap</parameter>
+        <parameter key="security.firewall.context.class">Symfony\Bundle\FrameworkBundle\Security\FirewallContext</parameter>
         <parameter key="security.matcher.class">Symfony\Component\HttpFoundation\RequestMatcher</parameter>
 
         <parameter key="security.role_hierarchy.class">Symfony\Component\Security\Role\RoleHierarchy</parameter>
@@ -157,8 +158,11 @@
             <tag name="kernel.listener" priority="-128" />
             <argument type="service" id="security.firewall.map" />
         </service>
-        <service id="security.firewall.map" class="%security.firewall.map.class%" public="false" />
-
+        <service id="security.firewall.map" class="%security.firewall.map.class%" public="false">
+            <argument type="service" id="service_container" />
+            <argument type="collection" />
+        </service>
+        
         <service id="security.context_listener" class="%security.context_listener.class%" public="false">
             <argument type="service" id="security.context" />
             <argument type="collection"></argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_templates.xml
@@ -85,5 +85,10 @@
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
+        
+        <service id="security.firewall.context" class="%security.firewall.context.class%" public="false">
+            <argument type="collection" />
+            <argument type="service" id="security.exception_listener" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Security/FirewallContext.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Security;
+
+use Symfony\Component\HttpKernel\Security\Firewall\ExceptionListener;
+
+/**
+ * This is a wrapper around the actual firewall configuration which allows us
+ * to lazy load the context for one specific firewall only when we need it.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class FirewallContext
+{
+    protected $listeners;
+    protected $exceptionListener;
+
+    public function __construct(array $listeners, ExceptionListener $exceptionListener)
+    {
+        $this->listeners = $listeners;
+        $this->exceptionListener = $exceptionListener;
+    }
+
+    public function getContext()
+    {
+        return array($this->listeners, $this->exceptionListener);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Security/FirewallMap.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Security;
+
+use Symfony\Component\HttpKernel\Security\FirewallMapInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * This is a lazy-loading firewall map implementation
+ *
+ * Listeners will only be initialized if we really need them.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class FirewallMap implements FirewallMapInterface
+{
+    protected $container;
+    protected $map;
+
+    public function __construct(ContainerInterface $container, array $map)
+    {
+        $this->container = $container;
+        $this->map = $map;
+    }
+
+    public function getListeners(Request $request)
+    {
+        foreach ($this->map as $contextId => $requestMatcher) {
+            if (null === $requestMatcher || $requestMatcher->matches($request)) {
+                return $this->container->get($contextId)->getContext();
+            }
+        }
+
+        return array(array(), null);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -22,7 +22,16 @@ class RequestMatcher implements RequestMatcherInterface
     protected $host;
     protected $methods;
     protected $ip;
-    protected $attributes = array();
+    protected $attributes;
+
+    public function __construct($path = null, $host = null, $methods = null, $ip = null, array $attributes = array())
+    {
+        $this->path = $path;
+        $this->host = $host;
+        $this->methods = $methods;
+        $this->ip = $ip;
+        $this->attributes = $attributes;
+    }
 
     /**
      * Adds a check for the URL host name.

--- a/src/Symfony/Component/HttpKernel/Security/Firewall.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall.php
@@ -37,7 +37,7 @@ class Firewall
      *
      * @param FirewallMap $map A FirewallMap instance
      */
-    public function __construct(FirewallMap $map)
+    public function __construct(FirewallMapInterface $map)
     {
         $this->map = $map;
         $this->currentListeners = array();
@@ -71,12 +71,12 @@ class Firewall
         // disconnect all listeners from core.security to avoid the overhead
         // of most listeners having to do this manually
         $this->dispatcher->disconnect('core.security');
-        
+
         // ensure that listeners disconnect from wherever they have connected to
         foreach ($this->currentListeners as $listener) {
             $listener->unregister($this->dispatcher);
         }
-        
+
         // register listeners for this firewall
         list($listeners, $exception) = $this->map->getListeners($request);
         if (null !== $exception) {
@@ -85,7 +85,7 @@ class Firewall
         foreach ($listeners as $listener) {
             $listener->register($this->dispatcher);
         }
-        
+
         // save current listener instances
         $this->currentListeners = $listeners;
         if (null !== $exception) {

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/FormAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/FormAuthenticationListener.php
@@ -60,7 +60,7 @@ abstract class FormAuthenticationListener
     }
 
     /**
-     * 
+     *
      *
      * @param EventDispatcher $dispatcher An EventDispatcher instance
      * @param integer         $priority   The priority
@@ -69,7 +69,7 @@ abstract class FormAuthenticationListener
     {
         $dispatcher->connect('core.security', array($this, 'handle'), 0);
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/src/Symfony/Component/HttpKernel/Security/FirewallMap.php
+++ b/src/Symfony/Component/HttpKernel/Security/FirewallMap.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Security\Firewall\ExceptionListener;
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  */
-class FirewallMap
+class FirewallMap implements FirewallMapInterface
 {
     protected $map = array();
 

--- a/src/Symfony/Component/HttpKernel/Security/FirewallMapInterface.php
+++ b/src/Symfony/Component/HttpKernel/Security/FirewallMapInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This interface must be implemented by firewall maps.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface FirewallMapInterface
+{
+    /**
+     * Returns the authentication listeners, and the exception listener to use
+     * for the given request.
+     *
+     * If there are no authentication listeners, the first inner are must be
+     * empty.
+     *
+     * If there is no exception listener, the second element of the outer array
+     * must be null.
+     *
+     * @param Request $request
+     * @return array of the format array(array(AuthenticationListener), ExceptionListener)
+     */
+    function getListeners(Request $request);
+}


### PR DESCRIPTION
This adds lazy loading for firewall configurations. This is useful when you have multiple firewalls, only the firewalls which are actually needed to process the Request are initialized. So, your event dispatcher is not as costly to initialize anymore.

It also implements re-using of RequestMatchers if all matching rules are the same, and exposes the remaining rules which are already implemented by the request matcher (host, ip, methods) in the access-control section, or was there a reason not to expose these?
