### PR TITLE
FormAuthenticationListener renaming

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -33,9 +33,7 @@ class FormLoginFactory implements SecurityFactoryInterface
         // listener
         $listenerId = 'security.authentication.listener.form.'.$id;
         $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.authentication.listener.form'));
-        $arguments = $listener->getArguments();
-        $arguments[1] = new Reference($provider);
-        $listener->setArguments($arguments);
+        $listener->setArgument(1, new Reference($provider));
 
         $options = array(
             'check_path'                     => '/login_check',
@@ -53,7 +51,7 @@ class FormLoginFactory implements SecurityFactoryInterface
                 $options[$key] = $config[$key];
             }
         }
-        $container->setParameter('security.authentication.form.options', $options);
+        $listener->setArgument(2, $options);
         $container->setParameter('security.authentication.form.login_path', $options['login_path']);
         $container->setParameter('security.authentication.form.use_forward', $options['use_forward']);
 

--- a/src/Symfony/Component/HttpKernel/Security/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Authentication\Token\UsernamePasswordToken;
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  */
-class UsernamePasswordFormAuthenticationListener extends FormAuthenticationListener
+class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationListener
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
I've changed the name of the form authentication listener since it has caused some confusion as to when this listener can be used; I also expanded the doc comments in this regard.

Since you have changed the name over the Spring implementation, I'm sure you had some reasons to do so, but I think we need to find something better than "Form" since this should be the preferred listener when people implement their own listener. I also considered "Base", or "Default" but "Abstract" seemed more fitting, what do you think?
