### PR TITLE
Sid retrieval tweak

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/SecurityIdentityRetrievalStrategy.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Acl\Domain;
 
+use Symfony\Component\Security\Authentication\Token\AnonymousToken;
+
 use Symfony\Component\Security\User\AccountInterface;
 use Symfony\Component\Security\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
@@ -49,9 +51,12 @@ class SecurityIdentityRetrievalStrategy implements SecurityIdentityRetrievalStra
         $sids = array();
 
         // add user security identity
-        $user = $token->getUser();
-        if ($user instanceof AccountInterface) {
-            $sids[] = UserSecurityIdentity::fromAccount($user);
+        if (!$token instanceof AnonymousToken) {
+            try {
+                $sids[] = UserSecurityIdentity::fromToken($token);
+            } catch (\InvalidArgumentException $invalid) {
+                // ignore, user has no user security identity
+            }
         }
 
         // add all reachable roles

--- a/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Acl\Domain;
 
+use Symfony\Component\Security\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\User\AccountInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 
@@ -51,7 +52,24 @@ class UserSecurityIdentity implements SecurityIdentityInterface
      */
     public static function fromAccount(AccountInterface $user)
     {
-        return new self((string) $user, get_class($user));
+        return new self($user->getUsername(), get_class($user));
+    }
+
+    /**
+     * Creates a user security identity from a TokenInterface
+     *
+     * @param TokenInterface $token
+     * @return UserSecurityIdentity
+     */
+    public static function fromToken(TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if ($user instanceof AccountInterface) {
+            return self::fromAccount($user);
+        }
+
+        return new self((string) $user, is_object($user)? get_class($user) : get_class($token));
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
@@ -29,20 +29,25 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
      */
     public function testEquals($id1, $id2, $equal)
     {
-        if ($equal) {
-            $this->assertTrue($id1->equals($id2));
-        } else {
-            $this->assertFalse($id1->equals($id2));
-        }
+        $this->assertSame($equal, $id1->equals($id2));
     }
 
     public function getCompareData()
     {
-        $account = $this->getMock('Symfony\Component\Security\User\AccountInterface');
+        $account = $this->getMockBuilder('Symfony\Component\Security\User\AccountInterface')
+                            ->setMockClassName('USI_AccountImpl')
+                            ->getMock();
         $account
-            ->expects($this->once())
-            ->method('__toString')
+            ->expects($this->any())
+            ->method('getUsername')
             ->will($this->returnValue('foo'))
+        ;
+
+        $token = $this->getMock('Symfony\Component\Security\Authentication\Token\TokenInterface');
+        $token
+            ->expects($this->any())
+            ->method('getUser')
+            ->will($this->returnValue($account))
         ;
 
         return array(
@@ -52,6 +57,8 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             array(new UserSecurityIdentity('foo', 'Foo'), UserSecurityIdentity::fromAccount($account), false),
             array(new UserSecurityIdentity('bla', 'Foo'), new UserSecurityIdentity('blub', 'Foo'), false),
             array(new UserSecurityIdentity('foo', 'Foo'), new RoleSecurityIdentity('foo'), false),
+            array(new UserSecurityIdentity('foo', 'Foo'), UserSecurityIdentity::fromToken($token), false),
+            array(new UserSecurityIdentity('foo', 'USI_AccountImpl'), UserSecurityIdentity::fromToken($token), true),
         );
     }
 }


### PR DESCRIPTION
This brings our implementation in alignment with the Spring implementation which also allows this (we didn't because a string is no object in PHP).

The following tokens can now also have a security identity:
- Tokens which only have a string as user
- Tokens where the user object does not implement AccountInterface, but which implement a __toString() method
