### PR TITLE
Form listener tweak

### DIFF
--- a/src/Symfony/Component/HttpKernel/Security/Firewall/FormAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/FormAuthenticationListener.php
@@ -61,7 +61,6 @@ abstract class FormAuthenticationListener
 
     /**
      *
-     *
      * @param EventDispatcher $dispatcher An EventDispatcher instance
      * @param integer         $priority   The priority
      */
@@ -91,11 +90,17 @@ abstract class FormAuthenticationListener
         }
 
         try {
-            if (null === $token = $this->attemptAuthentication($request)) {
+            if (null === $returnValue = $this->attemptAuthentication($request)) {
                 return;
             }
 
-            $response = $this->onSuccess($request, $token);
+            if ($returnValue instanceof TokenInterface) {
+                $response = $this->onSuccess($request, $returnValue);
+            } else if ($returnValue instanceof Response) {
+                $response = $returnValue;
+            } else {
+                throw new \RuntimeException('attemptAuthentication() must either return a Response, an implementation of TokenInterface, or null.');
+            }
         } catch (AuthenticationException $failed) {
             $response = $this->onFailure($event->getSubject(), $request, $failed);
         }


### PR DESCRIPTION
A small tweak of the form listener. In subclasses, you normally only implement attemptAuthentication(), but some listeners like OpenId for example need to be able to redirect to perform the authentication. Since we have no global response object that we can pass to the method, we need to allow to also return a response object from the attemptAuthentication() method.
