### PR TITLE
Exception improvement

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -89,7 +89,7 @@ class HttpKernel implements HttpKernelInterface
 
         // load controller
         if (false === $controller = $this->resolver->getController($request)) {
-            throw new NotFoundHttpException('Unable to find the controller.');
+            throw new NotFoundHttpException('Unable to find the controller for '.$request->getPathInfo().', check your route configuration.');
         }
 
         $event = new Event($this, 'core.controller', array('request_type' => $type, 'request' => $request));


### PR DESCRIPTION
It's especially annoying because in the php error log in production you see you had controller not found problems but you don't see which url triggered it, so it makes it pretty hard to know if you have a legit url that throws 404s or if it's just weird bots or people scanning for vulnerabilities.
