### PR TITLE
Add synthetic attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -34,7 +34,7 @@
             This service definition only defines the scope of the request.
             It is used to check references scope.
         -->
-        <service id="request" scope="request" />
+        <service id="request" scope="request" synthetic="true" />
 
         <service id="response" class="%response.class%" scope="prototype">
             <call method="setCharset">

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -28,6 +28,7 @@ class Definition
     protected $configurator;
     protected $tags;
     protected $public;
+    protected $synthetic;
 
     /**
      * Constructor.
@@ -43,6 +44,7 @@ class Definition
         $this->scope = ContainerInterface::SCOPE_CONTAINER;
         $this->tags = array();
         $this->public = true;
+        $this->synthetic = false;
     }
 
     /**
@@ -375,6 +377,32 @@ class Definition
     public function isPublic()
     {
         return $this->public;
+    }
+
+    /**
+     * Sets whether this definition is synthetic, that is not constructed by the
+     * container, but dynamically injected.
+     *
+     * @param Boolean $boolean
+     *
+     * @return Definition the current instance
+     */
+    public function setSynthetic($boolean)
+    {
+        $this->synthetic = (Boolean) $boolean;
+
+        return $this;
+    }
+
+    /**
+     * Whether this definition is synthetic, that is not constructed by the
+     * container, but dynamically injected.
+     *
+     * @return Boolean
+     */
+    public function isSynthetic()
+    {
+        return $this->synthetic;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -12,9 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-
 use Symfony\Component\DependencyInjection\Alias;
-
 use Symfony\Component\DependencyInjection\InterfaceInjector;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -139,7 +137,7 @@ class XmlFileLoader extends FileLoader
 
         $definition = new Definition();
 
-        foreach (array('class', 'scope', 'public', 'factory-method', 'factory-service') as $key) {
+        foreach (array('class', 'scope', 'public', 'factory-method', 'factory-service', 'synthetic') as $key) {
             if (isset($service[$key])) {
                 $method = 'set'.str_replace('-', '', $key);
                 $definition->$method((string) $service->getAttributeAsPhp($key));

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\Alias;
-
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\InterfaceInjector;
 use Symfony\Component\DependencyInjection\Definition;
@@ -146,6 +145,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['scope'])) {
             $definition->setScope($service['scope']);
+        }
+
+        if (isset($service['synthetic'])) {
+            $definition->setSynthetic($service['synthetic']);
         }
 
         if (isset($service['public'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -103,6 +103,7 @@
     <xsd:attribute name="class" type="xsd:string" />
     <xsd:attribute name="scope" type="xsd:string" />
     <xsd:attribute name="public" type="boolean" />
+    <xsd:attribute name="synthetic" type="boolean" />
     <xsd:attribute name="factory-method" type="xsd:string" />
     <xsd:attribute name="factory-service" type="xsd:string" />
     <xsd:attribute name="alias" type="xsd:string" />

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
@@ -126,6 +126,18 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\DependencyInjection\Definition::setSynthetic
+     * @covers Symfony\Component\DependencyInjection\Definition::isSynthetic
+     */
+    public function testSetIsSynthetic()
+    {
+        $def = new Definition('stdClass');
+        $this->assertFalse($def->isSynthetic(), '->isSynthetic() returns false by default');
+        $this->assertSame($def, $def->setSynthetic(true), '->setSynthetic() implements a fluent interface');
+        $this->assertTrue($def->isSynthetic(), '->isSynthetic() returns true if the instance must not be public.');
+    }
+
+    /**
      * @covers Symfony\Component\DependencyInjection\Definition::setConfigurator
      * @covers Symfony\Component\DependencyInjection\Definition::getConfigurator
      */


### PR DESCRIPTION
A small addition to the Definition. This allows us to hint services that are dynamically injected at runtime, and not constructed by the DIC. Mainly, this allows us to display better error messages and the container looks less hacky ;)

Naming is taken from Spring, but I think most "normal" users will never see this.
