### PR TITLE
Add migrate session

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -169,6 +169,15 @@ class Session implements \Serializable
     }
 
     /**
+     * Migrates the current session to a new session id while maintaining all
+     * session attributes.
+     */
+    public function migrate()
+    {
+        $this->storage->regenerate();
+    }
+
+    /**
      * Returns the session ID
      *
      * @return mixed  The session ID


### PR DESCRIPTION
This adds a migrate() method to the Session. In contrast to invalidate() it does not remove the existing session attributes, but only generates a new session id.
