### PR TITLE
Doctrine auto generate proxy bug

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -66,6 +66,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function mergeDbalConfig(array $configs, $container)
     {
+        $configs = array_reverse($configs);
+
         $supportedConnectionParams = array(
             'dbname'                => 'dbname',
             'host'                  => 'host',
@@ -214,6 +216,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     public function ormLoad(array $configs, ContainerBuilder $container)
     {
+        $configs = array_reverse($configs);
+
         $loader = new XmlFileLoader($container, __DIR__.'/../Resources/config');
         $loader->load('orm.xml');
 
@@ -281,10 +285,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $mergedConfig['default_connection'] = $config['default_connection'];
             }
             if (isset($config['auto_generate_proxy_classes'])) {
-                $mergedConfig['auto_generate_proxy_classes'] = $config['auto_generate_proxy_classes'];
+                $defaultManagerOptions['auto_generate_proxy_classes'] = $config['auto_generate_proxy_classes'];
             }
             if (isset($config['auto-generate-proxy-classes'])) {
-                $mergedConfig['auto_generate_proxy_classes'] = $config['auto-generate-proxy-classes'];
+                $defaultManagerOptions['auto_generate_proxy_classes'] = $config['auto-generate-proxy-classes'];
             }
         }
         $defaultManagerOptions['connection'] = $mergedConfig['default_connection'];

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -424,33 +424,33 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         ));
     }
 
-    public function testMultipleOrmLoadCalls()
+    public function testOrmMergeConfigs()
     {
         $container = $this->getContainer(array('XmlBundle', 'AnnotationsBundle'));
         $loader = new DoctrineExtension();
 
         $loader->dbalLoad(array(array()), $container);
         $loader->ormLoad(array(array(
-                'auto_generate_proxy_dir' => true,
+                'auto_generate_proxy_classes' => true,
                 'mappings' => array('AnnotationsBundle' => array())
             ),
             array(
-                'auto_generate_proxy_dir' => false,
+                'auto_generate_proxy_classes' => false,
                 'mappings' => array('XmlBundle' => array())
         )), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', array(
-            new Reference('doctrine.orm.default_annotation_metadata_driver'),
-            'DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Entity'
-        ));
-        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', array(
             new Reference('doctrine.orm.default_xml_metadata_driver'),
             'DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\XmlBundle\Entity'
         ));
+        $this->assertDICDefinitionMethodCallAt(1, $definition, 'addDriver', array(
+            new Reference('doctrine.orm.default_annotation_metadata_driver'),
+            'DoctrineBundle\Tests\DependencyInjection\Fixtures\Bundles\AnnotationsBundle\Entity'
+        ));
 
         $configDef = $container->getDefinition('doctrine.orm.default_configuration');
-        $this->assertDICDefinitionMethodCallOnce($configDef, 'setAutoGenerateProxyClasses', array(false));
+        $this->assertDICDefinitionMethodCallOnce($configDef, 'setAutoGenerateProxyClasses', array(true));
     }
 
     public function testEntityManagerMetadataCacheDriverConfiguration()


### PR DESCRIPTION
It seems i introudced a bug while doing the merge refactoring. I increased coverage for this scenario.

However I came across a weird case, and that is if i have the "orm_imports.xml" config which imports the "orm_imports_import.xml", then DoctrineExtension::ormLoad($configs) is passed the dev/prod configuration first and the "default" configuration second.

For a useful overwriting mechanism this would mean I have to array_reverse these values.

Is this intended?
