### PR TITLE
Removed assumption that explicit phpunit configuration is relative

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -63,9 +63,9 @@ abstract class WebTestCase extends BaseWebTestCase
         // find the --configuration flag from PHPUnit
         $cli = implode(' ', $_SERVER['argv']);
         if (preg_match('/\-\-configuration[= ]+([^ ]+)/', $cli, $matches)) {
-            $dir = $dir.'/'.$matches[1];
+            $dir = realpath($matches[1]);
         } elseif (preg_match('/\-c +([^ ]+)/', $cli, $matches)) {
-            $dir = $dir.'/'.$matches[1];
+            $dir = realpath($matches[1]);
         } elseif (file_exists(getcwd().'/phpunit.xml') || file_exists(getcwd().'/phpunit.xml.dist')) {
             $dir = getcwd();
         } else {


### PR DESCRIPTION
Previously:

if (preg_match('/--configuration[= ]+([^ ]+)/', $cli, $matches)) {
  $dir = $dir.'/'.$matches[1];
}

which works if the --configuration is a relative path, but not absolute. Instead realpath will work for both cases:

if (preg_match('/--configuration[= ]+([^ ]+)/', $cli, $matches)) {
  $dir = realpath($matches[1]);
}
