### PR TITLE
Fix filebag with subrequest

### DIFF
--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -39,9 +39,7 @@ class FileBag extends ParameterBag
      */
     public function set($key, $value)
     {
-        if (is_array($value)) {
-            parent::set($key, $this->convertFileInformation($value));
-        }
+        parent::set($key, $this->convertFileInformation($value));
     }
 
     /**
@@ -62,25 +60,28 @@ class FileBag extends ParameterBag
      *
      * @return array A (multi-dimensional) array of UploadedFile instances
      */
-    protected function convertFileInformation(array $file)
+    protected function convertFileInformation($file)
     {
-        $file = $this->fixPhpFilesArray($file);
         if (is_array($file)) {
-            $keys = array_keys($file);
-            sort($keys);
-            if ($keys == $this->fileKeys) {
-                $file['error'] = (int) $file['error'];
-            }
-            if ($keys != $this->fileKeys) {
-                $file = array_map(array($this, 'convertFileInformation'), $file);
-            } else
-                if ($file['error'] === UPLOAD_ERR_NO_FILE) {
-                    $file = null;
-                } else {
-                    $file = new UploadedFile($file['tmp_name'], $file['name'],
-                    $file['type'], $file['size'], $file['error']);
+            $file = $this->fixPhpFilesArray($file);
+            if (is_array($file)) {
+                $keys = array_keys($file);
+                sort($keys);
+                if ($keys == $this->fileKeys) {
+                    $file['error'] = (int) $file['error'];
                 }
+                if ($keys != $this->fileKeys) {
+                    $file = array_map(array($this, 'convertFileInformation'), $file);
+                } else
+                    if ($file['error'] === UPLOAD_ERR_NO_FILE) {
+                        $file = null;
+                    } else {
+                        $file = new UploadedFile($file['tmp_name'], $file['name'],
+                        $file['type'], $file['size'], $file['error']);
+                    }
+            }
         }
+
         return $file;
     }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/FileBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/FileBagTest.php
@@ -110,6 +110,16 @@ class FileBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($file, $files['child']['sub']['file']);
     }
 
+    public function testShouldNotConvertNestedUploadedFiles()
+    {
+        $tmpFile = $this->createTempFile();
+        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', 100, 0);
+        $bag = new FileBag(array('image' => array('file' => $file)));
+
+        $files = $bag->all();
+        $this->assertEquals($file, $files['image']['file']);
+    }
+
     protected function createTempFile()
     {
         return tempnam(sys_get_temp_dir(), 'FormTest');


### PR DESCRIPTION
FileBag generates an php fatal error when an new subrequest is created. Indeed, $_FILES has already been converted into instances of UploadedFile (stored in FileBag of master request)  and function convertFileInformation get an object (UploadedFile) rather than an array ($_FILES).

This is a quick fix, not sure this is the best. Feel free to suggest another fix if you want.
