### PR TITLE
Add OutputInterface->writeln()

### DIFF
--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -35,7 +35,7 @@ interface OutputInterface
      * @param string|array $messages The message as an array of lines of a single string
      * @param integer      $type     The type of output
      */
-    public function writeln($messages, $type = 0);
+    function writeln($messages, $type = 0);
 
     /**
      * Sets the verbosity of the output.


### PR DESCRIPTION
Many commands across the FrameworkBundle and DoctrineBundle use $output->writeln(), but it's not defined on OutputInterface which is passed into the execute method. So, in addition to making the interface not lie, it also makes autocomplete work nicely.
