### PR TITLE
Doctrine connection logging

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -154,7 +154,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
     {
         $containerDef = new Definition($container->getParameter('doctrine.dbal.configuration_class'));
         $containerDef->setPublic(false);
-        if (isset($connection['logging']) && $connection['logging']) {
+        if (isset($connection['container']['logging']) && $connection['container']['logging']) {
             $containerDef->addMethodCall('setSQLLogger', array(new Reference('doctrine.dbal.logger')));
         }
         $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $connection['name']), $containerDef);


### PR DESCRIPTION
Fixes a typo in DoctrineExtension that prohibited logging from working.
