### PR TITLE
added kernel to container during build

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -499,6 +499,8 @@ abstract class Kernel implements HttpKernelInterface, \Serializable
         $parameterBag = new ParameterBag($this->getKernelParameters());
 
         $container = new ContainerBuilder($parameterBag);
+        $container->set('kernel', $this);
+
         foreach ($this->bundles as $bundle) {
             $bundle->registerExtensions($container);
 


### PR DESCRIPTION
Since the kernel is added to the container at runtime it should also be there at buildtime.
