### PR TITLE
[SecurityBundle] Remove obsolete "path" option from HttpBasicFactory

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -36,10 +36,6 @@ class HttpBasicFactory implements SecurityFactoryInterface
         $listener = $container->setDefinition($listenerId, clone $container->getDefinition('security.authentication.listener.basic'));
         $listener->setArgument(2, $id);
 
-        if (isset($config['path'])) {
-            $container->setParameter('security.authentication.form.path', $config['path']);
-        }
-
         if (null === $defaultEntryPoint) {
             $defaultEntryPoint = 'security.authentication.basic_entry_point';
         }


### PR DESCRIPTION
I grepped the code and found no other references to that DIC param, so I assume this is obsolete.
