### PR TITLE
Serializers interface change

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -141,7 +141,7 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function addEncoder($format, EncoderInterface $encoder)
+    public function setEncoder($format, EncoderInterface $encoder)
     {
         $this->encoders[$format] = $encoder;
         $encoder->setSerializer($this);

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -80,7 +80,7 @@ interface SerializerInterface
      * @param string $format format name
      * @param EncoderInterface $encoder
      */
-    function addEncoder($format, EncoderInterface $encoder);
+    function setEncoder($format, EncoderInterface $encoder);
 
     /**
      * @param string $format format name

--- a/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
@@ -26,7 +26,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
     {
         $serializer = new Serializer;
         $this->encoder = new XmlEncoder;
-        $serializer->addEncoder('xml', $this->encoder);
+        $serializer->setEncoder('xml', $this->encoder);
         $serializer->addNormalizer(new CustomNormalizer);
     }
 

--- a/tests/Symfony/Tests/Component/Serializer/SerializerTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/SerializerTest.php
@@ -42,14 +42,14 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializeScalar()
     {
-        $this->serializer->addEncoder('json', new JsonEncoder());
+        $this->serializer->setEncoder('json', new JsonEncoder());
         $result = $this->serializer->serialize('foo', 'json');
         $this->assertEquals('"foo"', $result);
     }
 
     public function testSerializeArrayOfScalars()
     {
-        $this->serializer->addEncoder('json', new JsonEncoder());
+        $this->serializer->setEncoder('json', new JsonEncoder());
         $data = array('foo', array(5, 3));
         $result = $this->serializer->serialize($data, 'json');
         $this->assertEquals(json_encode($data), $result);
@@ -57,7 +57,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
     public function testEncode()
     {
-        $this->serializer->addEncoder('json', new JsonEncoder());
+        $this->serializer->setEncoder('json', new JsonEncoder());
         $data = array('foo', array(5, 3));
         $result = $this->serializer->encode($data, 'json');
         $this->assertEquals(json_encode($data), $result);
@@ -65,7 +65,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
     public function testDecode()
     {
-        $this->serializer->addEncoder('json', new JsonEncoder());
+        $this->serializer->setEncoder('json', new JsonEncoder());
         $data = array('foo', array(5, 3));
         $result = $this->serializer->decode(json_encode($data), 'json');
         $this->assertEquals($data, $result);


### PR DESCRIPTION
I feel that setters should take alias and value, while adders - only value, from which they internally extract the alias, e.g. Field, from which the take Field::getKey(), but I might be wrong
