### PR TITLE
Create DIC params for security user provider Entity/DocumentManager aliases

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -39,7 +39,8 @@
 
         <!-- security/user -->
         <parameter key="security.user.provider.entity.class">Symfony\Bundle\DoctrineBundle\Security\EntityUserProvider</parameter>
-        
+        <parameter key="security.user.entity_manager.alias">doctrine.orm.entity_manager</parameter>
+
         <!--  security/acl -->
         <parameter key="security.acl.collection_cache.class">Symfony\Bundle\DoctrineBundle\Security\AclCollectionCache</parameter>
 
@@ -56,7 +57,7 @@
             </call>
         </service>
 
-        <service id="security.user.entity_manager" alias="doctrine.orm.default_entity_manager" public="false" />
+        <service id="security.user.entity_manager" alias="%security.user.entity_manager.alias%" public="false" />
 
         <service id="request.param_converter.doctrine" class="Symfony\Bundle\DoctrineBundle\Request\ParamConverter\DoctrineConverter" public="false">
             <tag name="request.param_converter" />

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
@@ -50,7 +50,8 @@
 
     <!-- security/user -->
     <parameter key="security.user.provider.document.class">Symfony\Bundle\DoctrineMongoDBBundle\Security\DocumentUserProvider</parameter>
-    
+    <parameter key="security.user.document_manager.alias">doctrine.odm.mongodb.document_manager</parameter>
+
     <!-- validator -->
     <parameter key="doctrine_odm.mongodb.validator.unique.class">Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\DoctrineMongoDBUniqueValidator</parameter>
   </parameters>
@@ -87,8 +88,8 @@
       <argument type="service" id="doctrine.odm.mongodb.logger" />
     </service>
 
-    <service id="security.user.document_manager" alias="doctrine.odm.mongodb.default_document_manager" />
-    
+    <service id="security.user.document_manager" alias="%security.user.document_manager.alias%" />
+
     <!--  validator -->
     <service id="doctrine_odm.mongodb.validator.unique" class="%doctrine_odm.mongodb.validator.unique.class%">
         <argument type="service" id="doctrine.odm.mongodb.document_manager" />


### PR DESCRIPTION
srohweder in #symfony-dev mentioned that there was no simply way to configure the EM for the `security.user.entity_manager` service.  Doing so would require calling `setAlias()` on the container (e.g. from the main application bundle's extension).

This fix should allow us to just override the alias using the `parameters:` block in config.yml.
