### PR TITLE
init:bundle command added paramenter bundleName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 phpunit.xml
 autoload.php
 /vendor/
+.buildpath
+.project
+/.settings/


### PR DESCRIPTION
This pull adds optional parameter bundleName into init:bundle command so user can specify different than default bundle name. 
I've also added a validation of namespace and made destination directory more flexible (e.g. you don't need to add trailing / anymore)
help text is taken from pull 509 so thanks for that goes to weaverryan.

I'm sorry for changes in .gitignore, they are for eclipse project. It seems that I should do separate commits and pushes, unfortunately now I don't know how to fix that.
