### PR TITLE
Escaping

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
@@ -52,7 +52,7 @@ class TemplatingExtension extends \Twig_Extension
             'abbr_class'            => new \Twig_Filter_Method($this, 'abbrClass', array('is_safe' => array('html'))),
             'abbr_method'           => new \Twig_Filter_Method($this, 'abbrMethod', array('is_safe' => array('html'))),
             'format_args'           => new \Twig_Filter_Method($this, 'formatArgs', array('is_safe' => array('html'))),
-            'format_args_as_text'   => new \Twig_Filter_Method($this, 'formatArgsAsText', array('is_safe' => array('html'))),
+            'format_args_as_text'   => new \Twig_Filter_Method($this, 'formatArgsAsText'),
             'file_excerpt'          => new \Twig_Filter_Method($this, 'fileExcerpt', array('is_safe' => array('html'))),
             'format_file'           => new \Twig_Filter_Method($this, 'formatFile', array('is_safe' => array('html'))),
             'format_file_from_text' => new \Twig_Filter_Method($this, 'formatFileFromText', array('is_safe' => array('html'))),


### PR DESCRIPTION
This fixes the autoescaping for arguments. `format_args_as_text` is used in XML traces and it had to be escaped in this case (the output is clearly not html safe for this function)
