### PR TITLE
Mongodb validator fix

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -351,7 +351,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         if ($container->hasParameter('validator.annotations.namespaces')) {
             $container->setParameter('validator.annotations.namespaces', array_merge(
                 $container->getParameter('validator.annotations.namespaces'),
-                array('Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\\')
+                array('mongodb' => 'Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\\')
             ));
         }
     }

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
@@ -52,7 +52,7 @@
     <parameter key="security.user.provider.document.class">Symfony\Bundle\DoctrineMongoDBBundle\Security\DocumentUserProvider</parameter>
     
     <!-- validator -->
-    <parameter key="doctrine_odm.mongodb.validator.unique.class">Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\DoctrineMongoDBUniqueValidator</parameter>
+    <parameter key="doctrine_odm.mongodb.validator.unique.class">Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\UniqueValidator</parameter>
   </parameters>
 
   <services>
@@ -91,6 +91,7 @@
     
     <!--  validator -->
     <service id="doctrine_odm.mongodb.validator.unique" class="%doctrine_odm.mongodb.validator.unique.class%">
+        <tag name="validator.constraint_validator" alias="doctrine_odm.mongodb.unique" />
         <argument type="service" id="service_container" />
     </service>
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -2,14 +2,13 @@
 
 namespace Symfony\Bundle\DoctrineMongoDBBundle\Tests\Validator\Constraints;
 
-use Symfony\Bundle\DoctrineMongoDBBundle\Tests\Fixtures\Validator\Document;
-
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\DocumentRepository;
-use Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\DoctrineMongoDBUnique;
-use Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\DoctrineMongoDBUniqueValidator;
+use Symfony\Bundle\DoctrineMongoDBBundle\Tests\Fixtures\Validator\Document;
+use Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\Unique;
+use Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\UniqueValidator;
 
-class DoctrineMongoDBUniqueValidatorTest extends \PHPUnit_Framework_TestCase
+class UniqueValidatorTest extends \PHPUnit_Framework_TestCase
 {
     private $dm;
     private $repository;
@@ -23,7 +22,7 @@ class DoctrineMongoDBUniqueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->repository = $this->getDocumentRepository();
         $this->dm = $this->getDocumentManager($this->classMetadata, $this->repository);
         $container = $this->getContainer();
-        $this->validator = new DoctrineMongoDBUniqueValidator($container);
+        $this->validator = new UniqueValidator($container);
     }
 
     public function tearDown()
@@ -43,7 +42,7 @@ class DoctrineMongoDBUniqueValidatorTest extends \PHPUnit_Framework_TestCase
             ->with(array($path => $value))
             ->will($this->returnValue($return));
 
-        $this->assertTrue($this->validator->isValid($document, new DoctrineMongoDBUnique($path)));
+        $this->assertTrue($this->validator->isValid($document, new Unique($path)));
     }
 
     public function getFieldsPathsValuesDocumentsAndReturns()
@@ -72,7 +71,7 @@ class DoctrineMongoDBUniqueValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('findOneBy')
             ->with($query);
 
-        $this->validator->isValid($document, new DoctrineMongoDBUnique($path));
+        $this->validator->isValid($document, new Unique($path));
     }
 
     public function getFieldTypesFieldsPathsValuesAndQueries()

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Validator/Constraints/Unique.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Validator/Constraints/Unique.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraint;
  *
  * @author Bulat Shakirzyanov <bulat@theopenskyproject.com>
  */
-class DoctrineMongoDBUnique extends Constraint
+class Unique extends Constraint
 {
     public $message = 'The value for {{ property }} already exists.';
     public $path;
@@ -36,7 +36,7 @@ class DoctrineMongoDBUnique extends Constraint
 
     public function validatedBy()
     {
-        return 'doctrine_odm.mongodb.validator.unique';
+        return 'doctrine_odm.mongodb.unique';
     }
 
     public function targets()

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Validator/Constraints/UniqueValidator.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\ConstraintValidator;
  *
  * @author Bulat Shakirzyanov <bulat@theopenskyproject.com>
  */
-class DoctrineMongoDBUniqueValidator extends ConstraintValidator
+class UniqueValidator extends ConstraintValidator
 {
 
     private $container;
@@ -130,7 +130,7 @@ class DoctrineMongoDBUniqueValidator extends ConstraintValidator
         return $value;
     }
 
-    private function getDocumentManager(DoctrineMongoDBUnique $constraint)
+    private function getDocumentManager(Unique $constraint)
     {
         return $this->container->get($constraint->getDocumentManagerId());
     }


### PR DESCRIPTION
fixed unique validator registration in DIC, same namespace alias cannot be used for more than one namespace, so I had to change it to `mongodb`, that is why I also renamed validator class names to keep it shorter than `@mongodb:DoctrineMongoDBUnique` and keep it as `@mongodb:Unique`
