### PR TITLE
[DoctrineMongoDBBundle] Add is_dir() check before loading ODM fixtures for all bundles

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -70,6 +70,7 @@ EOT
             foreach ($this->container->get('kernel')->getBundles() as $bundle) {
                 $paths[] = $bundle->getPath().'/DataFixtures/MongoDB';
             }
+            $paths = array_filter($paths, 'is_dir');
         }
 
         $loader = new \Doctrine\Common\DataFixtures\Loader();


### PR DESCRIPTION
Restore Bulat's fix (with slight logic change) in 558268331b53e9eaaf4f6d14e585ccbb9a6c1a5c, which was removed in 57ae50e8942f1a3ee9431c320b404fc1b016b87c.
