### PR TITLE
Cache warmer priority

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheWarmerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheWarmerPass.php
@@ -38,7 +38,7 @@ class AddCacheWarmerPass implements CompilerPassInterface
         }
 
         // sort by priority and flatten
-        ksort($warmers);
+        krsort($warmers);
         $warmers = call_user_func_array('array_merge', $warmers);
 
         $container->getDefinition('cache_warmer')->setArgument(0, $warmers);


### PR DESCRIPTION
For example, the AsseticBundle has a routing loader that relies on the asset manager, which requires a warm cache. This only works if the asset manager's cache warmer runs before the router cache warmer.
