### PR TITLE
Doctrine generate annotations prefix

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -70,7 +70,7 @@ abstract class DoctrineCommand extends Command
     {
         $entityGenerator = new EntityGenerator();
 
-        if (version_compare(\Doctrine\ORM\Version, "2.0.2-DEV") >= 0) {
+        if (version_compare(\Doctrine\ORM\Version::VERSION, "2.0.2-DEV") >= 0) {
             $entityGenerator->setAnnotationPrefix("orm:");
         }
         $entityGenerator->setGenerateAnnotations(false);


### PR DESCRIPTION
Implement support for annotations prefixes in code generation as supported since patch https://github.com/doctrine/doctrine2/commit/4a020f2c480fa56f44b12ddc9e88ee397034e32d in Doctrine 2.
