### PR TITLE
Update Doctrine migrations commands for new bundle style.

### DIFF
--- a/src/Symfony/Bundle/DoctrineMigrationsBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineMigrationsBundle/Command/DoctrineCommand.php
@@ -25,11 +25,10 @@ abstract class DoctrineCommand extends BaseCommand
 {
     public static function configureMigrationsForBundle(Application $application, $bundle, Configuration $configuration)
     {
-        $configuration->setMigrationsNamespace($bundle.'\DoctrineMigrations');
-
         $bundle = $application->getKernel()->getBundle($bundle);
         $dir = $bundle->getPath().'/DoctrineMigrations';
 
+        $configuration->setMigrationsNamespace($bundle->getNamespace().'\DoctrineMigrations');
         $configuration->setMigrationsDirectory($dir);
         $configuration->registerMigrationsFromDirectory($dir);
         $configuration->setName($bundle->getName().' Migrations');


### PR DESCRIPTION
Updates the Doctrine migrations commands to work with the newer bundle style. Migrations console commands now expect the bundle short name for their `--bundle="Foo"` argument.
