### PR TITLE
[TwigBundle] Fix exception message in filesystem loader

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -93,7 +93,7 @@ class FilesystemLoader implements \Twig_LoaderInterface
         }
 
         if (false === $file || null === $file) {
-            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', $name), 0, null, $previous);
+            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', json_encode($name)), 0, null, $previous);
         }
 
         return $this->cache[$key] = $file;


### PR DESCRIPTION
The template name is an array here.
