### PR TITLE
Fix class declared twice in test fixtures

### DIFF
--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/containers/interfaces1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/containers/interfaces1.php
@@ -12,12 +12,14 @@ $container->setDefinition('foo', $definition);
 
 return $container;
 
-class FooClass
-{
-    public $bar;
-
-    public function setBar($bar)
+if(!class_exists('FooClass')) {
+    class FooClass
     {
-        $this->bar = $bar;
+        public $bar;
+
+        public function setBar($bar)
+        {
+            $this->bar = $bar;
+        }
     }
 }


### PR DESCRIPTION
All 4 test classes in tests/Symfony/Tests/Component/DependencyInjection/Dumper/ include this interface1.php file.
The FooClass class should be declared only once.
