### PR TITLE
Phpdoc blocks (fixed verbs)

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser.php
@@ -25,7 +25,7 @@ namespace Symfony\Component\CssSelector;
 class Parser
 {
     /**
-     * Translate a CSS expression to its XPath equivalent.
+     * Translates a CSS expression to its XPath equivalent.
      * Optionally, a prefix can be added to the resulting XPath
      * expression with the $prefix parameter.
      *
@@ -71,7 +71,7 @@ class Parser
     }
 
     /**
-     * Parse an expression and return the Node object that represents
+     * Parses an expression and returns the Node object that represents
      * the parsed expression.
      *
      * @throws \Exception When tokenizer throws it while parsing
@@ -96,7 +96,7 @@ class Parser
     }
 
     /**
-     * Parse a selector group contained in $stream and return
+     * Parses a selector group contained in $stream and returns
      * the Node object that represents the expression.
      *
      * @param  TokenStream $stream The stream to parse.
@@ -123,7 +123,7 @@ class Parser
     }
 
     /**
-     * Parse a selector contained in $stream and return the Node
+     * Parses a selector contained in $stream and returns the Node
      * object that represents it.
      *
      * @throws SyntaxError When expected selector but got something else
@@ -159,7 +159,7 @@ class Parser
     }
 
     /**
-     * Parse a simple selector (the current token) from $stream and return
+     * Parses a simple selector (the current token) from $stream and returns
      * the resulting Node object.
      *
      * @throws SyntaxError When expected symbol but got something else
@@ -266,7 +266,7 @@ class Parser
     }
 
     /**
-     * Parse an attribute from a selector contained in $stream and return
+     * Parses an attribute from a selector contained in $stream and returns
      * the resulting AttribNode object.
      *
      * @throws SyntaxError When encountered unexpected selector

--- a/src/Symfony/Component/CssSelector/Token.php
+++ b/src/Symfony/Component/CssSelector/Token.php
@@ -50,7 +50,7 @@ class Token
     }
 
     /**
-     * Answer whether this token's type equals to $type.
+     * Answers whether this token's type equals to $type.
      *
      * @param  string $type The type to test against this token's one.
      *

--- a/src/Symfony/Component/CssSelector/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/TokenStream.php
@@ -79,7 +79,7 @@ class TokenStream
     }
 
     /**
-     * Peek for the next token in this stream. This means that the next token
+     * Peeks for the next token in this stream. This means that the next token
      * will be returned but it won't be considered as used (visited) until the
      * next() method is invoked.
      * If there are no remaining tokens null will be returned.

--- a/src/Symfony/Component/CssSelector/Tokenizer.php
+++ b/src/Symfony/Component/CssSelector/Tokenizer.php
@@ -22,7 +22,7 @@ namespace Symfony\Component\CssSelector;
 class Tokenizer
 {
     /**
-     * Take a CSS selector and return an array holding the Tokens
+     * Takes a CSS selector and returns an array holding the Tokens
      * it contains.
      *
      * @param  string $s The selector to lex.
@@ -103,8 +103,8 @@ class Tokenizer
     }
 
     /**
-     * Tokenize a quoted string (i.e. 'A string quoted with \' characters'),
-     * and return an array holding the unquoted string contained by $s and
+     * Tokenizes a quoted string (i.e. 'A string quoted with \' characters'),
+     * and returns an array holding the unquoted string contained by $s and
      * the new position from which tokenizing should take over.
      *
      * @throws SyntaxError When expected closing is not found
@@ -142,7 +142,7 @@ class Tokenizer
     }
 
     /**
-     * Unescape a string literal and return the unescaped string.
+     * Unescapes a string literal and returns the unescaped string.
      *
      * @throws SyntaxError When invalid escape sequence is found
      *
@@ -166,7 +166,7 @@ class Tokenizer
     }
 
     /**
-     * Lex selector $s and return the an array holding the name of the symbol
+     * Lexes selector $s and returns an array holding the name of the symbol
      * contained in it and the new position from which tokenizing should take
      * over.
      *

--- a/src/Symfony/Component/CssSelector/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPathExpr.php
@@ -66,7 +66,7 @@ class XPathExpr
     }
 
     /**
-     * Answer whether this XPath expression has a star prefix.
+     * Answers whether this XPath expression has a star prefix.
      *
      * @return bool
      */
@@ -121,7 +121,7 @@ class XPathExpr
     }
 
     /**
-     * Add a condition to this XPath expression.
+     * Adds a condition to this XPath expression.
      * Any pre-existant condition will be ANDed to it.
      *
      * @param string $condition The condition to add.
@@ -136,7 +136,7 @@ class XPathExpr
     }
 
     /**
-     * Add a prefix to this XPath expression.
+     * Adds a prefix to this XPath expression.
      * It will be prepended to any pre-existant prefixes.
      *
      * @param string $prefix  The prefix to add.
@@ -151,7 +151,7 @@ class XPathExpr
     }
 
     /**
-     * Add a condition to this XPath expression using the name of the element
+     * Adds a condition to this XPath expression using the name of the element
      * as the desired value.
      * This method resets the element to '*'.
      */
@@ -167,7 +167,7 @@ class XPathExpr
     }
 
     /**
-     * Add a star prefix to this XPath expression.
+     * Adds a star prefix to this XPath expression.
      * This method will prepend a '*' to the path and set the star prefix flag
      * to true.
      */
@@ -187,7 +187,7 @@ class XPathExpr
     }
 
     /**
-     * Join this XPath expression with $other (another XPath expression) using
+     * Joins this XPath expression with $other (another XPath expression) using
      * $combiner to join them.
      *
      * @param string    $combiner The combiner string.


### PR DESCRIPTION
Fixed the starting lines of the PHPDoc blocks for first-level classes inside CssSelector Component.
