### PR TITLE
[FrameworkBundle] RedirectController generates invalid url with unnecessary parameter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -47,7 +47,7 @@ class RedirectController extends ContainerAware
         $code = $permanent ? 301 : 302;
 
         $attributes = $this->container->get('request')->attributes->all();
-        unset($attributes['_route'], $attributes['route']);
+        unset($attributes['_route'], $attributes['route'], $attributes['permanent'] );
 
         $response = $this->container->get('response');
         $response->setRedirect($this->container->get('router')->generate($route, $attributes), $code);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Bundle\FrameworkBundle\Tests\Logger;
+use Symfony\Bundle\FrameworkBundle\Tests\Kernel;
+
+
+
+/**
+ * 
+ * @author Marcin Sikon<marcin.sikon@gmail.com>
+ */
+class RedirectControllerTest extends TestCase
+{
+    public function testEmptyRoute()
+    {
+        $response = new Response();
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('response'))
+            ->will($this->returnValue($response))
+        ;
+        
+        $controller = new RedirectController();
+        $controller->setContainer($container);
+        
+        $returnResponse = $controller->redirectAction('');
+        
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
+        
+        $this->assertEquals(410, $returnResponse->getStatusCode());
+    }
+    
+    
+    
+    /**
+     * @dataProvider provider
+     */
+    public function testRoute($permanent, $expectedCode)
+    {
+        $response = new Response();
+        $request = new Request();
+        
+        $route = 'new-route';
+        $url = '/redirect-url';
+        $params = array('additional-parameter' => 'value');
+        
+        
+        $request->attributes = new ParameterBag(array('route' => $route, '_route' => 'current-route', 'permanent' => $permanent) + $params);
+        
+        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with($this->equalTo($route),$this->equalTo($params))
+            ->will($this->returnValue($url));
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        
+        $container
+            ->expects($this->at(0))
+            ->method('get')
+            ->with($this->equalTo('request'))
+            ->will($this->returnValue($request));
+            
+        $container
+            ->expects($this->at(1))
+            ->method('get')
+            ->with($this->equalTo('response'))
+            ->will($this->returnValue($response));
+            
+        $container
+            ->expects($this->at(2))
+            ->method('get')
+            ->with($this->equalTo('router'))
+            ->will($this->returnValue($router));
+        
+        
+        $controller = new RedirectController();
+        $controller->setContainer($container);
+        
+        $returnResponse = $controller->redirectAction($route, $permanent);
+        
+        
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
+        
+        $this->assertTrue($returnResponse->isRedirect());
+        $this->assertTrue($returnResponse->isRedirected($url));
+        $this->assertEquals($expectedCode, $returnResponse->getStatusCode());
+    }
+    
+
+
+    public function provider()
+    {
+        return array(
+            array(true, 301),
+            array(false, 302),
+        );
+    }
+    
+}


### PR DESCRIPTION
Hi
I removed parameter 'permanent' before generating the path and I added tests for this class
