### PR TITLE
[HttpKernel] Catch exception when SQLite profiler storage fails to cleanup

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/SQLiteProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/SQLiteProfilerStorage.php
@@ -94,11 +94,11 @@ class SQLiteProfilerStorage implements ProfilerStorageInterface
         );
         try {
             $this->exec($db, 'INSERT INTO data (token, data, ip, url, time, created_at) VALUES (:token, :data, :ip, :url, :time, :created_at)', $args);
+            $this->cleanup();
             $status = true;
         } catch (\Exception $e) {
             $status = false;
         }
-        $this->cleanup();
         $this->close($db);
 
         return $status;


### PR DESCRIPTION
Sorry about the `if(` in the previous pull request.
