### PR TITLE
Test cleanup

### DIFF
--- a/tests/Symfony/Tests/Component/HttpFoundation/File/MimeType/MimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/MimeType/MimeTypeTest.php
@@ -65,13 +65,14 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException');
         MimeTypeGuesser::getInstance()->guess($path);
-
-
     }
+
     public static function tearDownAfterClass()
     {
         $path = __DIR__.'/../Fixtures/to_delete';
-        chmod($path, 0666);
-        @unlink($path);
+        if (file_exists($path)) {
+            chmod($path, 0666);
+            @unlink($path);
+        }
     }
 }


### PR DESCRIPTION
This cleanup triggers an error when using a --filter that doesn't include this test.
