### PR TITLE
StringOutput class

### DIFF
--- a/src/Symfony/Component/Console/Output/StringOutput.php
+++ b/src/Symfony/Component/Console/Output/StringOutput.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+/**
+ * StringOutput saves the output in a string variable.
+ *
+ * @author Christian Hammers <ch@lathspell.de>
+ */
+class StringOutput extends Output
+{
+    /** @var string */
+    private $string = '';
+
+    /**
+     * Constructor.
+     *
+     * @param integer $verbosity The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL, self::VERBOSITY_VERBOSE)
+     * @param Boolean $decorated Whether to decorate messages or not (null for auto-guessing)
+     */
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null)
+    {
+        parent::__construct($verbosity, $decorated);
+    }
+
+    /**
+     * Writes a message into the string buffer.
+     *
+     * @param string  $message A message to write to the output
+     * @param Boolean $newline Whether to add a newline or not
+     */
+    public function doWrite($message, $newline) {
+        $this->string .= $message . ($newline ? "\n" : '');
+    }
+
+    /**
+     * Retrieve the output string.
+     *
+     * @return string
+     */
+    public function getString() {
+        return $this->string;
+    }
+}

--- a/tests/Symfony/Tests/Component/Console/Output/StringOutputTest.php
+++ b/tests/Symfony/Tests/Component/Console/Output/StringOutputTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Console\Output;
+
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\StringOutput;
+
+class StringOutputTest extends \PHPUnit_Framework_TestCase
+{
+    protected $string;
+
+    protected function setUp()
+    {
+    }
+
+    public function testConstructor()
+    {
+        $output = new StringOutput(Output::VERBOSITY_QUIET, true);
+        $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '__construct() takes the verbosity as its first argument');
+        $this->assertTrue($output->isDecorated(), '__construct() takes the decorated flag as its second argument');
+    }
+
+    public function testDoWrite()
+    {
+        $output = new StringOutput();
+        $output->writeln('foo');
+        $this->assertEquals('foo'.PHP_EOL, $output->getString(), '->doWrite() writes to the string');
+    }
+}


### PR DESCRIPTION
Hello

I wrote a StringOutput class (including a unit test) to be able to unit test the commands of a CLI-only Symfony2 application.

After some curious search how you do the tests of the framework without such a class I found the fopen("php://memory") trick but this is far from obvious (aka ugly hack) and would surely get many people to give up and go without tests.

(Meanwhile I got noticed of a quite similar pull request at https://github.com/fabpot/symfony/pull/473 but that seemed to be rejected due to a discouraged _use case_ and because the implementation was wrong)
