### PR TITLE
Fix typo introduced in d447d22809e3751c5d6c

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/LoadDataFixturesDoctrineCommand.php
@@ -72,7 +72,7 @@ EOT
             }
         }
 
-        $loader = $loader = new \Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader($this->container);
+        $loader = new \Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader($this->container);
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $loader->loadFromDirectory($path);


### PR DESCRIPTION
Fix a $loader = $loader = new ... typo in src/Symfony/Bundle/DoctrineBundle/Command/LoadDataFixturesDoctrineCommand.php
