### PR TITLE
Form fix

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
@@ -192,6 +192,7 @@ class FormExtension extends \Twig_Extension
 
     protected function render(FieldInterface $field, $name, array $arguments, $resources = null)
     {
+        $resources = (array) $resources;
         if ('field' === $name) {
             list($name, $template) = $this->getWidget($field, $resources);
         } else {


### PR DESCRIPTION
fix to make `form_field(form, {}, {}, "MyBundle::form.html.twig")` possible again
