### PR TITLE
Form srand removal

### DIFF
--- a/src/Symfony/Component/Form/FileField.php
+++ b/src/Symfony/Component/Form/FileField.php
@@ -102,8 +102,6 @@ class FileField extends Form
      */
     protected function normalize($path)
     {
-        srand(microtime(true));
-
         return array(
             'file' => '',
             'token' => rand(100000, 999999),


### PR DESCRIPTION
php docs state:

```
Note: As of PHP 4.2.0, there is no need to seed the random number generator with srand() or mt_srand() as this is now done automatically.
```
