### PR TITLE
Mongodb document choice field

### DIFF
--- a/src/Symfony/Component/Form/MongoDBDocumentChoiceField.php
+++ b/src/Symfony/Component/Form/MongoDBDocumentChoiceField.php
@@ -1,0 +1,427 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+use Symfony\Component\Form\ValueTransformer\TransformationFailedException;
+use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\InvalidOptionsException;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ODM\MongoDB\Query\Builder;
+
+/**
+ * A field for selecting one or more from a list of Doctrine 2 MongoDB ODM documents
+ *
+ * You at least have to pass the document manager and the document class in the
+ * options "dm" and "class".
+ *
+ * <code>
+ * $form->add(new MongoDBDocumentChoiceField('tags', array(
+ *     'dm' => $dm,
+ *     'class' => 'Application\Document\Tag',
+ * )));
+ * </code>
+ *
+ * Additionally to the options in ChoiceField, the following options are
+ * available:
+ *
+ *  * dm:             The document manager. Required.
+ *  * class:          The class of the selectable documents. Required.
+ *  * property:       The property displayed as value of the choices. If this
+ *                    option is not available, the field will try to convert
+ *                    objects into strings using __toString().
+ *  * query_builder:  The query builder for fetching the selectable documents.
+ *                    You can also pass a closure that receives the repository
+ *                    as single argument and returns a query builder.
+ *
+ * The following sample outlines the use of the "query_builder" option
+ * with closures.
+ *
+ * <code>
+ * $form->add(new MongoDBDocumentChoiceField('tags', array(
+ *     'dm' => $dm,
+ *     'class' => 'Application\Document\Tag',
+ *     'query_builder' => function ($repository) {
+ *         return $repository->createQueryBuilder()->field('enabled')->equals(1);
+ *     },
+ * )));
+ * </code>
+ *
+ * @author Bernhard Schussek <bernhard.schussek@symfony-project.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ */
+class MongoDBDocumentChoiceField extends ChoiceField
+{
+    /**
+     * The documents from which the user can choose
+     *
+     * This array is either indexed by ID or by key in the choices array
+     * (if the ID consists of multiple fields)
+     *
+     * This property is initialized by initializeChoices(). It should only
+     * be accessed through getDocument() and getDocuments().
+     *
+     * @var Collection
+     */
+    protected $documents = null;
+
+    /**
+     * Contains the query builder that builds the query for fetching the
+     * documents
+     *
+     * This property should only be accessed through getQueryBuilder().
+     *
+     * @var Doctrine\ODM\MongoDB\Query\Builder
+     */
+    protected $queryBuilder = null;
+
+    /**
+     * A cache for \ReflectionProperty instances for the underlying class
+     *
+     * This property should only be accessed through getReflProperty().
+     *
+     * @var array
+     */
+    protected $reflProperties = array();
+
+    /**
+     * A cache for the UnitOfWork instance of Doctrine
+     *
+     * @var Doctrine\ODM\MongoDB\UnitOfWork
+     */
+    protected $unitOfWork = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this->addRequiredOption('dm');
+        $this->addRequiredOption('class');
+        $this->addOption('property');
+        $this->addOption('query_builder');
+
+        // Override option - it is not required for this subclass
+        $this->addOption('choices', array());
+
+        parent::configure();
+
+        // The documents can be passed directly in the "choices" option.
+        // In this case, initializing the document cache is a cheap operation
+        // so do it now!
+        if (is_array($this->getOption('choices')) && count($this->getOption('choices')) > 0) {
+            $this->initializeChoices();
+        }
+
+        // If a query builder was passed, it must be a closure or QueryBuilder
+        // instance
+        if ($qb = $this->getOption('query_builder')) {
+            if (!($qb instanceof Builder || $qb instanceof \Closure)) {
+                throw new InvalidOptionsException(
+                    'The option "query_builder" most contain a closure or a Query\Builder instance',
+                    array('query_builder'));
+            }
+        }
+    }
+
+    /**
+     * Returns the query builder instance for the choices of this field
+     *
+     * @return Doctrine\ODM\MongoDB\Query\Builder  The query builder
+     * @throws InvalidOptionsException    When the query builder was passed as
+     *                                    closure and that closure does not
+     *                                    return a QueryBuilder instance
+     */
+    protected function getQueryBuilder()
+    {
+        if (!$this->getOption('query_builder')) {
+            return null;
+        }
+
+        if (!$this->queryBuilder) {
+            $qb = $this->getOption('query_builder');
+
+            if ($qb instanceof \Closure) {
+                $class = $this->getOption('class');
+                $dm = $this->getOption('dm');
+                $qb = $qb($dm->getRepository($class));
+
+                if (!$qb instanceof Builder) {
+                    throw new InvalidOptionsException(
+                        'The closure in the option "query_builder" should return a Query\Builder instance',
+                        array('query_builder'));
+                }
+            }
+
+            $this->queryBuilder = $qb;
+        }
+
+        return $this->queryBuilder;
+    }
+
+    /**
+     * Returns the unit of work of the document manager
+     *
+     * This object is cached for faster lookups.
+     *
+     * @return Doctrine\ODM\MongoDB\UnitOfWork  The unit of work
+     */
+    protected function getUnitOfWork()
+    {
+        if (!$this->unitOfWork) {
+            $this->unitOfWork = $this->getOption('dm')->getUnitOfWork();
+        }
+
+        return $this->unitOfWork;
+    }
+
+    /**
+     * Initializes the choices and returns them
+     *
+     * The choices are generated from the documents.
+     *
+     * If the documents were passed in the "choices" option, this method
+     * does not have any significant overhead. Otherwise, if a query builder
+     * was passed in the "query_builder" option, this builder is now used
+     * to construct a query which is executed. In the last case, all documents
+     * for the underlying class are fetched from the repository.
+     *
+     * If the option "property" was passed, the property path in that option
+     * is used as option values. Otherwise this method tries to convert
+     * objects to strings using __toString().
+     *
+     * @return array  An array of choices
+     */
+    protected function getInitializedChoices()
+    {
+        if ($this->getOption('choices')) {
+            $documents = parent::getInitializedChoices();
+        } else if ($qb = $this->getQueryBuilder()) {
+            $documents = $qb->getQuery()->execute();
+        } else {
+            $class = $this->getOption('class');
+            $dm = $this->getOption('dm');
+            $documents = $dm->getRepository($class)->findAll();
+        }
+
+        $propertyPath = null;
+        $choices = array();
+        $this->documents = array();
+
+        // The propery option defines, which property (path) is used for
+        // displaying documents as strings
+        if ($this->getOption('property')) {
+            $propertyPath = new PropertyPath($this->getOption('property'));
+        }
+
+        foreach ($documents as $key => $document) {
+            if ($propertyPath) {
+                // If the property option was given, use it
+                $value = $propertyPath->getValue($document);
+            } else {
+                // Otherwise expect a __toString() method in the document
+                $value = (string)$document;
+            }
+
+            // When the identifier is a single field, index choices by
+            // document ID for performance reasons
+            $id = $this->getIdentifierValue($document);
+            $choices[$id] = $value;
+            $this->documents[$id] = $document;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * Returns the according documents for the choices
+     *
+     * If the choices were not initialized, they are initialized now. This
+     * is an expensive operation, except if the documents were passed in the
+     * "choices" option.
+     *
+     * @return array  An array of documents
+     */
+    protected function getDocuments()
+    {
+        if (!$this->documents) {
+            // indirectly initializes the documents property
+            $this->initializeChoices();
+        }
+
+        return $this->documents;
+    }
+
+    /**
+     * Returns the document for the given key
+     *
+     * If the underlying documents have composite identifiers, the choices
+     * are intialized. The key is expected to be the index in the choices
+     * array in this case.
+     *
+     * If they have single identifiers, they are either fetched from the
+     * internal document cache (if filled) or loaded from the database.
+     *
+     * @param  string $id  The document ID
+     * @return object       The matching document
+     */
+    protected function getDocument($id)
+    {
+        return $this->getOption('dm')->find($this->getOption('class'), $id);
+    }
+
+    /**
+     * Returns the \ReflectionProperty instance for a property of the
+     * underlying class
+     *
+     * @param  string $property     The name of the property
+     * @return \ReflectionProperty  The reflection instsance
+     */
+    protected function getReflProperty($property)
+    {
+        if (!isset($this->reflProperties[$property])) {
+            $this->reflProperties[$property] = new \ReflectionProperty($this->getOption('class'), $property);
+            $this->reflProperties[$property]->setAccessible(true);
+        }
+
+        return $this->reflProperties[$property];
+    }
+
+    /**
+     * Returns the values of the identifier fields of an document
+     *
+     * Doctrine must know about this document, that is, the document must already
+     * be persisted or added to the iddocument map before. Otherwise an
+     * exception is thrown.
+     *
+     * @param  object $document  The document for which to get the identifier
+     * @throws FormException   If the document does not exist in Doctrine's
+     *                         iddocument map
+     */
+    protected function getIdentifierValue($document)
+    {
+        if (!$this->getUnitOfWork()->isInIdentityMap($document)) {
+            throw new FormException('Documents passed to the choice field must be managed');
+        }
+
+        return $this->getUnitOfWork()->getDocumentIdentifier($document);
+    }
+
+    /**
+     * Merges the selected and deselected documents into the collection passed
+     * when calling setData()
+     *
+     * @see parent::processData()
+     */
+    protected function processData($data)
+    {
+        // reuse the existing collection to optimize for Doctrine
+        if ($data instanceof Collection) {
+            $currentData = $this->getData();
+
+            if (!$currentData) {
+                $currentData = $data;
+            } else if (count($data) === 0) {
+                $currentData->clear();
+            } else {
+                // merge $data into $currentData
+                foreach ($currentData as $document) {
+                    if (!$data->contains($document)) {
+                        $currentData->removeElement($document);
+                    } else {
+                        $data->removeElement($document);
+                    }
+                }
+
+                foreach ($data as $document) {
+                    $currentData->add($document);
+                }
+            }
+
+            return $currentData;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Transforms choice keys into documents
+     *
+     * @param  mixed $keyOrKeys   An array of keys, a single key or NULL
+     * @return Collection|object  A collection of documents, a single document
+     *                            or NULL
+     */
+    protected function reverseTransform($keyOrKeys)
+    {
+        $keyOrKeys = parent::reverseTransform($keyOrKeys);
+
+        if (null === $keyOrKeys) {
+            return $this->getOption('multiple') ? new ArrayCollection() : null;
+        }
+
+        $notFound = array_diff((array) $keyOrKeys, array_keys($this->getDocuments()));
+
+        if (0 === count($notFound)) {
+            if (is_array($keyOrKeys)) {
+                $result = new ArrayCollection();
+
+                // optimize this into a SELECT WHERE IN query
+                foreach ($keyOrKeys as $key) {
+                    try {
+                        $result->add($this->getDocument($key));
+                    } catch (NoResultException $e) {
+                        $notFound[] = $key;
+                    }
+                }
+            } else {
+                try {
+                    $result = $this->getDocument($keyOrKeys);
+                } catch (NoResultException $e) {
+                    $notFound[] = $keyOrKeys;
+                }
+            }
+        }
+
+        if (count($notFound) > 0) {
+            throw new TransformationFailedException(sprintf('The documents with keys "%s" could not be found', implode('", "', $notFound)));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Transforms documents into choice keys
+     *
+     * @param  Collection|object  A collection of documents, a single document or
+     *                            NULL
+     * @return mixed              An array of choice keys, a single key or
+     *                            NULL
+     */
+    protected function transform($collectionOrDocument)
+    {
+        if (null === $collectionOrDocument) {
+            return $this->getOption('multiple') ? array() : '';
+        }
+
+        if ($collectionOrDocument instanceof Collection) {
+            $result = array();
+
+            foreach ($collectionOrDocument as $document) {
+                $result[] = $this->getIdentifierValue($document);
+            }
+        } else {
+            $result = $this->getIdentifierValue($collectionOrDocument);
+        }
+
+        return parent::transform($result);
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/DoctrineMongoDBOdmTestCase.php
+++ b/tests/Symfony/Tests/Component/Form/DoctrineMongoDBOdmTestCase.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Form;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\MongoDB\Connection;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class DoctrineMongoDBOdmTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Doctrine\\Common\\Version')) {
+            $this->markTestSkipped('Doctrine is not available.');
+        }
+    }
+
+    /**
+     * @return DocumentManager
+     */
+    protected function createTestDocumentManager($paths = array())
+    {
+        $config = new \Doctrine\ODM\MongoDB\Configuration();
+        $config->setAutoGenerateProxyClasses(true);
+        $config->setProxyDir(\sys_get_temp_dir());
+        $config->setProxyNamespace('SymfonyTests\Doctrine\ODM\MongoDB');
+        $config->setHydratorDir(\sys_get_temp_dir());
+        $config->setHydratorNamespace('SymfonyTests\Doctrine\ODM\MongoDB');
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver($paths));
+        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
+        $conn = new Connection();
+        return DocumentManager::create($conn, $config);
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Fixtures/TestDocument.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/TestDocument.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+/** @Document */
+class TestDocument
+{
+    /** @Id(strategy="none") */
+    protected $id;
+
+    /** @String */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/MongoDBDocumentChoiceFieldTest.php
+++ b/tests/Symfony/Tests/Component/Form/MongoDBDocumentChoiceFieldTest.php
@@ -1,0 +1,411 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Form;
+
+require_once __DIR__.'/DoctrineMongoDBOdmTestCase.php';
+require_once __DIR__.'/Fixtures/TestDocument.php';
+
+use Symfony\Component\Form\MongoDBDocumentChoiceField;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Tests\Component\Form\Fixtures\TestDocument;
+use Doctrine\ORM\Tools\SchdmaTool;
+use Doctrine\Common\Collections\ArrayCollection;
+
+class MongoDBDocumentChoiceFieldTest extends DoctrineMongoDBOdmTestCase
+{
+    const DOCUMENT_CLASS = 'Symfony\Tests\Component\Form\Fixtures\TestDocument';
+
+    /**
+     * @var DocumentManager
+     */
+    private $dm;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->dm = $this->createTestDocumentManager();
+        $this->dm->getDocumentCollection(self::DOCUMENT_CLASS)->drop();
+    }
+
+    protected function persist(array $entities)
+    {
+        foreach ($entities as $document) {
+            $this->dm->persist($document);
+        }
+
+        $this->dm->flush();
+        // no clear, because entities managed by the choice field must
+        // be managed!
+    }
+
+    public function testNonRequiredContainsEmptyField()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+
+        $this->persist(array($document1, $document2));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'required' => false,
+            'property' => 'name'
+        ));
+
+        $this->assertEquals(array('' => '', 1 => 'Foo', 2 => 'Bar'), $field->getOtherChoices());
+    }
+
+//    public function testSetDataToUninitializedDocumentWithNonRequired()
+//    {
+//        $document1 = new TestDocument(1, 'Foo');
+//        $document2 = new TestDocument(2, 'Bar');
+//
+//        $this->persist(array($document1, $document2));
+//
+//        $field = new MongoDBDocumentChoiceField('name', array(
+//            'dm' => $this->dm,
+//            'class' => self::DOCUMENT_CLASS,
+//            'required' => false,
+//            'property' => 'name'
+//        ));
+//
+//        $this->assertEquals(array('' => '', 1 => 'Foo', 2 => 'Bar'), $field->getOtherChoices());
+//
+//    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\InvalidOptionsException
+     */
+    public function testConfigureQueryBuilderWithNonQueryBuilderAndNonClosure()
+    {
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'query_builder' => new \stdClass(),
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\InvalidOptionsException
+     */
+    public function testConfigureQueryBuilderWithClosureReturningNonQueryBuilder()
+    {
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'query_builder' => function () {
+                return new \stdClass();
+            },
+        ));
+
+        $field->submit('2');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\FormException
+     */
+    public function testChoicesMustBeManaged()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+
+        // no persist here!
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => false,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'choices' => array($document1, $document2),
+            'property' => 'name',
+        ));
+    }
+
+    public function testSetDataSingle_null()
+    {
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => false,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+        ));
+        $field->setData(null);
+
+        $this->assertEquals(null, $field->getData());
+        $this->assertEquals('', $field->getDisplayedData());
+    }
+
+    public function testSetDataMultiple_null()
+    {
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => true,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+        ));
+        $field->setData(null);
+
+        $this->assertEquals(null, $field->getData());
+        $this->assertEquals(array(), $field->getDisplayedData());
+    }
+
+    public function testSubmitSingle_null()
+    {
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => false,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+        ));
+        $field->submit(null);
+
+        $this->assertEquals(null, $field->getData());
+        $this->assertEquals('', $field->getDisplayedData());
+    }
+
+    public function testSubmitMultiple_null()
+    {
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => true,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+        ));
+        $field->submit(null);
+
+        $this->assertEquals(new ArrayCollection(), $field->getData());
+        $this->assertEquals(array(), $field->getDisplayedData());
+    }
+
+    public function testSubmitSingleNonExpanded_singleIdentifier()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+
+        $this->persist(array($document1, $document2));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => false,
+            'expanded' => false,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'property' => 'name',
+        ));
+
+        $field->submit('2');
+
+        $this->assertTrue($field->isTransformationSuccessful());
+        $this->assertEquals($document2, $field->getData());
+        $this->assertEquals(2, $field->getDisplayedData());
+    }
+
+    public function testSubmitMultipleNonExpanded_singleIdentifier()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+        $document3 = new TestDocument(3, 'Baz');
+
+        $this->persist(array($document1, $document2, $document3));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => true,
+            'expanded' => false,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'property' => 'name',
+        ));
+
+        $field->submit(array('1', '3'));
+
+        $expected = new ArrayCollection(array($document1, $document3));
+
+        $this->assertTrue($field->isTransformationSuccessful());
+        $this->assertEquals($expected, $field->getData());
+        $this->assertEquals(array(1, 3), $field->getDisplayedData());
+    }
+
+    public function testSubmitMultipleNonExpanded_singleIdentifier_existingData()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+        $document3 = new TestDocument(3, 'Baz');
+
+        $this->persist(array($document1, $document2, $document3));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => true,
+            'expanded' => false,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'property' => 'name',
+        ));
+
+        $existing = new ArrayCollection(array($document2));
+
+        $field->setData($existing);
+        $field->submit(array('1', '3'));
+
+        // entry with index 0 was rdmoved
+        $expected = new ArrayCollection(array(1 => $document1, 2 => $document3));
+
+        $this->assertTrue($field->isTransformationSuccessful());
+        $this->assertEquals($expected, $field->getData());
+        // same object still, useful if it is a PersistentCollection
+        $this->assertSame($existing, $field->getData());
+        $this->assertEquals(array(1, 3), $field->getDisplayedData());
+    }
+
+    public function testSubmitSingleExpanded()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+
+        $this->persist(array($document1, $document2));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => false,
+            'expanded' => true,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'property' => 'name',
+        ));
+
+        $field->submit('2');
+
+        $this->assertTrue($field->isTransformationSuccessful());
+        $this->assertEquals($document2, $field->getData());
+        $this->assertSame(false, $field['1']->getData());
+        $this->assertSame(true, $field['2']->getData());
+        $this->assertSame('', $field['1']->getDisplayedData());
+        $this->assertSame('1', $field['2']->getDisplayedData());
+        $this->assertSame(array('1' => '', '2' => '1'), $field->getDisplayedData());
+    }
+
+    public function testSubmitMultipleExpanded()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+        $document3 = new TestDocument(3, 'Bar');
+
+        $this->persist(array($document1, $document2, $document3));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'multiple' => true,
+            'expanded' => true,
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'property' => 'name',
+        ));
+
+        $field->submit(array('1' => '1', '3' => '3'));
+
+        $expected = new ArrayCollection(array($document1, $document3));
+
+        $this->assertTrue($field->isTransformationSuccessful());
+        $this->assertEquals($expected, $field->getData());
+        $this->assertSame(true, $field['1']->getData());
+        $this->assertSame(false, $field['2']->getData());
+        $this->assertSame(true, $field['3']->getData());
+        $this->assertSame('1', $field['1']->getDisplayedData());
+        $this->assertSame('', $field['2']->getDisplayedData());
+        $this->assertSame('1', $field['3']->getDisplayedData());
+        $this->assertSame(array('1' => '1', '2' => '', '3' => '1'), $field->getDisplayedData());
+    }
+
+    public function testOverrideChoices()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+        $document3 = new TestDocument(3, 'Baz');
+
+        $this->persist(array($document1, $document2, $document3));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            // not all persisted entities should be displayed
+            'choices' => array($document1, $document2),
+            'property' => 'name',
+        ));
+
+        $field->submit('2');
+
+        $this->assertEquals(array(1 => 'Foo', 2 => 'Bar'), $field->getOtherChoices());
+        $this->assertTrue($field->isTransformationSuccessful());
+        $this->assertEquals($document2, $field->getData());
+        $this->assertEquals(2, $field->getDisplayedData());
+    }
+
+    public function testDisallowChoicesThatAreNotIncluded_choices_singleIdentifier()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+        $document3 = new TestDocument(3, 'Baz');
+
+        $this->persist(array($document1, $document2, $document3));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'choices' => array($document1, $document2),
+            'property' => 'name',
+        ));
+
+        $field->submit('3');
+
+        $this->assertFalse($field->isTransformationSuccessful());
+        $this->assertNull($field->getData());
+    }
+
+    public function testDisallowChoicesThatAreNotIncluded_queryBuilder_singleIdentifier()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+        $document3 = new TestDocument(3, 'Baz');
+
+        $this->persist(array($document1, $document2, $document3));
+
+        $repository = $this->dm->getRepository(self::DOCUMENT_CLASS);
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'query_builder' => $repository->createQueryBuilder()
+                ->field('id')->in(array(1, 2)),
+            'property' => 'name',
+        ));
+
+        $field->submit('3');
+
+        $this->assertFalse($field->isTransformationSuccessful());
+        $this->assertNull($field->getData());
+    }
+
+    public function testDisallowChoicesThatAreNotIncluded_queryBuilderAsClosure_singleIdentifier()
+    {
+        $document1 = new TestDocument(1, 'Foo');
+        $document2 = new TestDocument(2, 'Bar');
+        $document3 = new TestDocument(3, 'Baz');
+
+        $this->persist(array($document1, $document2, $document3));
+
+        $field = new MongoDBDocumentChoiceField('name', array(
+            'dm' => $this->dm,
+            'class' => self::DOCUMENT_CLASS,
+            'query_builder' => function ($repository) {
+                return $repository->createQueryBuilder('e')
+                        ->field('id')->in(array(1, 2));
+            },
+            'property' => 'name',
+        ));
+
+        $field->submit('3');
+
+        $this->assertFalse($field->isTransformationSuccessful());
+        $this->assertNull($field->getData());
+    }
+}


### PR DESCRIPTION
I ported the EntityChoiceField that Bernard wrote so we can do the same thing for the Doctrine MongoDB ODM.

We need to discuss moving these widgets. They are in the form component currently but I don't think they should be there. I think they should be in the DoctrineBundle and DoctrineMongoDBBundle. We can have any Doctrine specific fields for the form framework there.
