### PR TITLE
Access denied handling

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -128,8 +128,6 @@ class ExceptionListener implements ListenerInterface
 
                         $response = $event->getSubject()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
                         $response->setStatusCode(403);
-
-                        return $response;
                     }
                 } catch (\Exception $e) {
                     if (null !== $this->logger) {


### PR DESCRIPTION
This fixes the handling of the AccessDeniedException using an error page. The response has to be returned with the final return statement after marking the event as processed. Without this fix the kernel throws the AccessDeniedException again.
