### PR TITLE
Add router resource type option to FrameworkExtension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -96,6 +96,7 @@ class Configuration
                 ->canBeUnset()
                 ->scalarNode('cache_warmer')->end()
                 ->scalarNode('resource')->isRequired()->end()
+                ->scalarNode('type')->end()
                 ->end()
         ;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -234,6 +234,10 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('routing.resource', $config['resource']);
 
+        if (isset($config['type'])) {
+            $container->setParameter('router.options.resource_type', $config['type']);
+        }
+
         if (isset($config['cache_warmer']) && $config['cache_warmer']) {
             $container->getDefinition('router.cache_warmer')->addTag('kernel.cache_warmer');
             $container->setAlias('router', 'router.cached');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -22,6 +22,7 @@
         <parameter key="router.cache_warmer.class">Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer</parameter>
         <parameter key="router.options.matcher.cache_class">%kernel.name%%kernel.environment%UrlMatcher</parameter>
         <parameter key="router.options.generator.cache_class">%kernel.name%%kernel.environment%UrlGenerator</parameter>
+        <parameter key="router.options.resource_type" />
     </parameters>
 
     <services>
@@ -71,6 +72,7 @@
                 <argument key="matcher_base_class">%router.options.matcher_base_class%</argument>
                 <argument key="matcher_dumper_class">%router.options.matcher_dumper_class%</argument>
                 <argument key="matcher_cache_class">%router.options.matcher.cache_class%</argument>
+                <argument key="resource_type">%router.options.resource_type%</argument>
             </argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -63,8 +63,9 @@
     </xsd:complexType>
 
     <xsd:complexType name="router">
-        <xsd:attribute name="resource" type="xsd:string" />
         <xsd:attribute name="cache-warmer" type="cache_warmer" />
+        <xsd:attribute name="resource" type="xsd:string" />
+        <xsd:attribute name="type" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="session">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -13,8 +13,9 @@ $container->loadFromExtension('app', 'config', array(
         'only_exceptions' => true,
     ),
     'router' => array(
-        'resource'     => '%kernel.root_dir%/config/routing.xml',
         'cache_warmer' => true,
+        'resource'     => '%kernel.root_dir%/config/routing.xml',
+        'type'         => 'xml',
     ),
     'session' => array(
         'auto_start'     => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -10,7 +10,7 @@
         <app:csrf-protection enabled="true" field-name="_csrf" secret="s3cr3t" />
         <app:esi enabled="true" />
         <app:profiler only-exceptions="true" />
-        <app:router resource="%kernel.root_dir%/config/routing.xml" cache-warmer="true" />
+        <app:router cache-warmer="true" resource="%kernel.root_dir%/config/routing.xml" type="xml" />
         <app:session auto-start="true" class="Session" default-locale="fr" storage-id="native" name="_SYMFONY" lifetime="86400" path="/" domain="example.com" secure="true" httponly="true" />
         <app:templating assets-version="SomeVersionScheme" assets-base-urls="http://cdn.example.com" cache-warmer="true">
             <app:loader>loader.foo</app:loader>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -8,8 +8,9 @@ app.config:
     profiler:
         only_exceptions: true
     router:
-        resource:     %kernel.root_dir%/config/routing.xml
         cache_warmer: true
+        resource:     %kernel.root_dir%/config/routing.xml
+        type:         xml
     session:
         auto_start:     true
         class:          Session

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -51,6 +51,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('router.real'), '->registerRouterConfiguration() loads routing.xml');
         $this->assertEquals($container->getParameter('kernel.root_dir').'/config/routing.xml', $container->getParameter('routing.resource'), '->registerRouterConfiguration() sets routing resource');
+        $this->assertEquals('xml', $container->getParameter('router.options.resource_type'), '->registerRouterConfiguration() sets routing resource type');
         $this->assertTrue($container->getDefinition('router.cache_warmer')->hasTag('kernel.cache_warmer'), '->registerRouterConfiguration() tags router cache warmer if cache warming is set');
         $this->assertEquals('router.cached', (string) $container->getAlias('router'), '->registerRouterConfiguration() changes router alias to cached if cache warming is set');
     }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -35,8 +35,9 @@ class Router implements RouterInterface
      *
      * Available options:
      *
-     *   * cache_dir: The cache directory (or null to disable caching)
-     *   * debug:     Whether to enable debugging or not (false by default)
+     *   * cache_dir:     The cache directory (or null to disable caching)
+     *   * debug:         Whether to enable debugging or not (false by default)
+     *   * resource_type: Type hint for the main resource (optional)
      *
      * @param LoaderInterface $loader A LoaderInterface instance
      * @param mixed           $resource The main resource to load
@@ -63,6 +64,7 @@ class Router implements RouterInterface
             'matcher_base_class'     => 'Symfony\\Component\\Routing\\Matcher\\UrlMatcher',
             'matcher_dumper_class'   => 'Symfony\\Component\\Routing\\Matcher\\Dumper\\PhpMatcherDumper',
             'matcher_cache_class'    => 'ProjectUrlMatcher',
+            'resource_type'          => null,
         );
 
         // check option names
@@ -81,7 +83,7 @@ class Router implements RouterInterface
     public function getRouteCollection()
     {
         if (null === $this->collection) {
-            $this->collection = $this->loader->load($this->resource);
+            $this->collection = $this->loader->load($this->resource, $this->options['resource_type']);
         }
 
         return $this->collection;


### PR DESCRIPTION
The router LoaderInterface class already supported a type parameter, but the top-level Router class had no suppport for it.
