### PR TITLE
[Routing] Avoid locating imported resources as files unless they resolve to a FileLoader

### DIFF
--- a/src/Symfony/Component/Routing/Loader/FileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/FileLoader.php
@@ -40,13 +40,15 @@ abstract class FileLoader extends Loader
      * @param string $type     The resource type
      *
      * @return RouteCollection A RouteCollection instance
+     *
+     * @throws \InvalidArgumentException When resource is expected to be a file and cannot be found
      */
     public function import($resource, $type = null)
     {
         $loader = $this->resolve($resource, $type);
 
         if ($loader instanceof FileLoader && null !== $this->currentDir) {
-            $resource = $this->locator->getAbsolutePath($resource, $this->currentDir);
+            $resource = $this->locator->locate($resource, $this->currentDir);
         }
 
         return $loader->load($resource, $type);

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -56,7 +56,6 @@ class XmlFileLoader extends FileLoader
                     $type = (string) $node->getAttribute('type');
                     $prefix = (string) $node->getAttribute('prefix');
                     $this->currentDir = dirname($path);
-                    $file = $this->locator->locate($resource, $this->currentDir);
                     $collection->addCollection($this->import($file, $type), $prefix);
                     break;
                 default:

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -57,7 +57,6 @@ class YamlFileLoader extends FileLoader
                 $type = isset($config['type']) ? $config['type'] : null;
                 $prefix = isset($config['prefix']) ? $config['prefix'] : null;
                 $this->currentDir = dirname($path);
-                $file = $this->locator->locate($config['resource'], $this->currentDir);
                 $collection->addCollection($this->import($file, $type), $prefix);
             } elseif (isset($config['pattern'])) {
                 $this->parseRoute($collection, $name, $config, $path);


### PR DESCRIPTION
Fixes problems Kris Wallsmith was having with importing Assetic resources from an XML or YAML routing file.
