### PR TITLE
Router XmlFileLoader "type" attribute for imported resources

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -56,7 +56,7 @@ class XmlFileLoader extends FileLoader
                     $type = (string) $node->getAttribute('type');
                     $prefix = (string) $node->getAttribute('prefix');
                     $this->currentDir = dirname($path);
-                    $collection->addCollection($this->import($resource, $type), $prefix);
+                    $collection->addCollection($this->import($resource, ('' !== $type ? $type : null)), $prefix);
                     break;
                 default:
                     throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));


### PR DESCRIPTION
Currently, a missing "type" attribute results in an empty string being passed to `FileLoader::import()`.  This should actually be null.
