### PR TITLE
Concurrent session

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ConcurrentSessionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ConcurrentSessionListener.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Firewall;
+
+use Symfony\Component\EventDispatcher\EventInterface;
+use Symfony\Component\Security\Http\Session\SessionRegistry;
+use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\HttpKernel\Log\LoggerInterface;
+
+class ConcurrentSessionListener extends ContextListener
+{
+    protected $sessionRegistry;
+
+    public function __construct(SecurityContext $context, array $userProviders, $contextKey, SessionRegistry $sessionRegistry, LoggerInterface $logger = null)
+    {
+        parent::__construct($context, $userProviders, $contextKey, $logger);
+
+        $this->sessionRegistry = $sessionRegistry;
+    }
+
+    /**
+     * Reads the Token from the session, checks if the session is marked as expired in the session registry.
+     *
+     * @param EventInterface $event An EventInterface instance
+     */
+    public function read(EventInterface $event)
+    {
+        $request = $event->get('request');
+        $session = $request->getSession();
+
+        $token = $this->getToken($session);
+
+        if (null !== $token) {
+            if (null === $sessionInformation = $this->sessionRegistry->getSessionInformation($session->getId())) {
+                $sessions = $this->sessionRegistry->getAllSessions($token->getUser());
+                if ($sessions->count() > 0) {
+                    $token = null;
+                }
+            } elseif ($sessionInformation->isExpired()) {
+                $this->sessionRegistry->removeSessionInformation($session->getId(), $token->getUser());
+                $session->invalidate();
+                $token = null;
+            }
+        }
+
+        if (null !== $token && false === $token->isImmutable()) {
+            $token = $this->refreshUser($token);
+        }
+
+        $this->context->setToken($token);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Session/ConcurrentSessionControlStrategy.php
+++ b/src/Symfony/Component/Security/Http/Session/ConcurrentSessionControlStrategy.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Session;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\AccountInterface;
+
+/**
+ * ConcurrentSessionControlStrategy.
+ *
+ * Strategy which handles concurrent session-control, in addition to the functionality provided by the base class.
+ * When invoked following an authentication, it will check whether the user in question should be allowed to proceed,
+ * by comparing the number of sessions they already have active with the configured maximumSessions value.
+ * The SessionRegistry is used as the source of data on authenticated users and session data.
+ *
+ * @author Stefan Paschke <stefan.paschke@gmail.com>
+ */
+class ConcurrentSessionControlStrategy extends SessionAuthenticationStrategy
+{
+    protected $registry;
+    protected $alwaysCreateSession;
+    protected $exceptionIfMaximumExceeded = false;
+    protected $maximumSessions;
+
+    public function __construct($maximumSessions, SessionRegistry $registry, $sessionAuthenticationStrategy = null)
+    {
+        parent::__construct($sessionAuthenticationStrategy);
+        $this->registry = $registry;
+        $this->setMaximumSessions($maximumSessions);
+    }
+
+    /**
+     * Called when a user is newly authenticated.
+     *
+     * @param Request $request
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function onAuthentication(Request $request, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        $originalSessionId = $request->getSession()->getId();
+
+        parent::onAuthentication($request, $token);
+
+        if ($originalSessionId != $request->getSession()->getId()) {
+            $this->onSessionChange($originalSessionId, $request->getSession()->getId(), $token);
+        }
+
+        $sessions       = $this->registry->getAllSessions($user);
+        $maxSessions    = $this->getMaximumSessionsForThisUser($user);
+
+        if ($sessions->count() >= $maxSessions && $this->alwaysCreateSession !== true) {
+            if ($this->exceptionIfMaximumExceeded) {
+                throw new \RuntimeException(sprintf('Maximum of sessions (%s) exceeded', $maxSessions));
+            }
+
+            $this->allowableSessionsExceeded($sessions, $maxSessions, $this->registry);
+        }
+
+        $this->registry->registerNewSession($request->getSession()->getID(), $user);
+    }
+
+    /**
+     * Sets a boolean flag that allows to bypass allowableSessionsExceeded().
+     *
+     * param boolean $alwaysCreateSession
+     * @return void
+     */
+    public function setAlwaysCreateSession($alwaysCreateSession)
+    {
+        $this->alwaysCreateSession = $alwaysCreateSession;
+    }
+
+    /**
+     * Sets a boolean flag that causes a RuntimeException to be thrown if the number of sessions is exceeded.
+     *
+     * @param boolean $exceptionIfMaximumExceeded
+     * @return void
+     */
+    public function setExceptionIfMaximumExceeded($exceptionIfMaximumExceeded)
+    {
+        $this->exceptionIfMaximumExceeded = $exceptionIfMaximumExceeded;
+    }
+
+    /**
+     * Sets the maxSessions property.
+     *
+     * @param $maximumSessions
+     * @return void
+     */
+    public function setMaximumSessions($maximumSessions)
+    {
+        $this->maximumSessions = $maximumSessions;
+    }
+
+    /**
+     * Allows subclasses to customise behaviour when too many sessions are detected.
+     *
+     * @param SessionInformationIterator $sessions
+     * @param integer $allowableSessions
+     * @param SessionRegistry $registry
+     * @return void
+     */
+    protected function allowableSessionsExceeded(SessionInformationIterator $sessions, $allowableSessions, SessionRegistry $registry)
+    {
+        // remove oldest sessions from registry
+        $count = 0;
+        $sessions->sort();
+
+        for ($i = $allowableSessions - 1; $i < $sessions->count(); $i++) {
+            $sessions[$i]->expireNow();
+            $registry->setSessionInformation($sessions[$i]);
+        }
+    }
+
+    /**
+     * Method intended for use by subclasses to override the maximum number of sessions that are permitted for a particular authentication.
+     *
+     * @param AccountInterface $user
+     * @return integer
+     */
+    protected function getMaximumSessionsForThisUser(AccountInterface $user)
+    {
+        return $this->maximumSessions;
+    }
+
+    /**
+     * Called when the session has been changed and the old attributes have been migrated to the new session.
+     *
+     * @param string $originalSessionId
+     * @param string $newSessionId
+     * @param TokenInterface $token
+     * @return void
+     */
+    protected function onSessionChange($originalSessionId, $newSessionId, TokenInterface $token)
+    {
+        $this->registry->removeSessionInformation($originalSessionId, $token->getUser());
+    }
+}

--- a/src/Symfony/Component/Security/Http/Session/SessionInformation.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionInformation.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Session;
+
+use Symfony\Component\Security\Core\User\AccountInterface;
+
+/**
+ * SessionInformation.
+ *
+ * Represents a record of a session. This is primarily used for concurrent session support.
+ *
+ * @author Stefan Paschke <stefan.paschke@gmail.com>
+ */
+class SessionInformation
+{
+    protected $sessionId;
+    protected $user;
+    protected $expired;
+    protected $lastRequest;
+
+    public function __construct($sessionId, AccountInterface $user)
+    {
+        $this->sessionId = $sessionId;
+        $this->user = $user;
+    }
+
+    /**
+     * Sets the session informations expired date to the current date and time.
+     *
+     * @return void
+     */
+    public function expireNow()
+    {
+        $this->expired = time();
+    }
+
+    /**
+     * Obtain the last request date.
+     *
+     * @return integer UNIX Timestamp of the last request date and time.
+     */
+    public function getLastRequest()
+    {
+        return $this->lastRequest;
+    }
+
+    /**
+     * Obtains the user.
+     *
+     * @return AccountInterface
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * Obtain the session identifier.
+     *
+     * @return string $sessionId the session identifier key.
+     */
+    public function getSessionId()
+    {
+        return $this->sessionId;
+    }
+
+    /**
+     * Return wether this session is expired.
+     *
+     * @return boolean
+     */
+    public function isExpired()
+    {
+        return $this->expired && $this->expired < time();
+    }
+
+    /**
+     * Set the last request date to the current date and time.
+     *
+     * @return void
+     */
+    public function refreshLastRequest()
+    {
+        $this->lastRequest = time();
+    }
+}

--- a/src/Symfony/Component/Security/Http/Session/SessionInformationIterator.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionInformationIterator.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Session;
+
+/**
+ * SessionInformationIterator.
+ *
+ * @author Stefan Paschke <stefan.paschke@gmail.com>
+ */
+class SessionInformationIterator implements \Iterator, \ArrayAccess
+{
+    protected $sessions = array();
+    protected $position = 0;
+
+    /**
+     * Iterator interface.
+     *
+     * @return void
+     */
+    public function rewind()
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * Iterator interface.
+     *
+     * @return SessionInformation
+     */
+    public function current()
+    {
+        return $this->sessions[$this->position];
+    }
+
+    /**
+     * Iterator interface.
+     *
+     * @return integer
+     */
+    public function key()
+    {
+        return $this->position;
+    }
+
+    /**
+     * Iterator interface.
+     *
+     * @return void
+     */
+    public function next()
+    {
+        $this->position++;
+    }
+
+    /**
+     * Iterator interface.
+     *
+     * @return boolean
+     */
+    public function valid()
+    {
+        return isset($this->sessions[$this->position]);
+    }
+
+    /**
+     * ArrayAccess interface.
+     *
+     * @return boolean
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->sessions[$offset]);
+    }
+
+    /**
+     * ArrayAccess interface.
+     *
+     * @return SessionInformation
+     */
+    public function offsetGet($offset)
+    {
+        return $this->sessions[$offset];
+    }
+
+    /**
+     * ArrayAccess interface.
+     *
+     * @param integer $offset
+     * @param SessionInformation $sessionInformation
+     * @return void
+     */
+    public function offsetSet($offset, $sessionInformation)
+    {
+        if ($sessionInformation instanceof SessionInformation) {
+            $this->sessions[$offset] = $sessionInformation;
+        }
+    }
+
+    /**
+     * ArrayAccess interface.
+     *
+     * @param integer $offset
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        if ($this->offsetExists($offset)) {
+            unset($this->sessions[$offset]);
+        }
+    }
+
+    /**
+     * Adds a SessionInformation object to the iterator.
+     *
+     * @param SessionInformation $sessionInformation
+     * @return void
+     */
+    public function add(SessionInformation $sessionInformation)
+    {
+        $this->sessions[] = $sessionInformation;
+    }
+
+    /**
+     * Sorts the session informations by the last request date.
+     *
+     * @return void
+     */
+    function sort()
+    {
+        $sessionsSorted = array();
+        foreach ($this->sessions as $session) {
+            $sessionsSorted[$session->getLastRequest()] = $session;
+        }
+        krsort($sessionsSorted);
+
+        $this->sessions = array_values($sessionsSorted);
+    }
+
+    /**
+     * Returns the number of session information objects.
+     *
+     * @return integer
+     */
+    function count()
+    {
+        return count($this->sessions);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Session/SessionRegistry.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionRegistry.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Session;
+
+use Symfony\Component\Security\Core\User\AccountInterface;
+
+/**
+ * SessionRegistry.
+ *
+ * Maintains a registry of SessionInformation instances.
+ *
+ * @author Stefan Paschke <stefan.paschke@gmail.com>
+ */
+class SessionRegistry
+{
+    protected $sessionRegistryStorage;
+    protected $sessionInformationClass;
+    protected $sessionInformationIteratorClass;
+
+    public function __construct(SessionRegistryStorageInterface $sessionRegistryStorage, $sessionInformationClass = 'Symfony\Component\Security\Http\Session\SessionInformation', $sessionInformationIteratorClass = 'Symfony\Component\Security\Http\Session\SessionInformationIterator')
+    {
+        $this->sessionRegistryStorage = $sessionRegistryStorage;
+        $this->sessionInformationClass = $sessionInformationClass;
+        $this->sessionInformationIteratorClass = $sessionInformationIteratorClass;
+    }
+
+    /**
+     * Obtains all the users for which session information is stored.
+     *
+     * @return array An array of AccountInterface objects.
+     */
+    public function getAllUsers()
+    {
+        return $this->sessionRegistryStorage->getUsers();
+    }
+
+    /**
+     * Obtains all the known sessions for the specified user.
+     *
+     * @param AccountInterface $user the specified user.
+     * @param boolean $includeExpiredSessions.
+     * @return SessionInformationIterator $sessions the known sessions.
+     */
+    public function getAllSessions(AccountInterface $user, $includeExpiredSessions = false)
+    {
+        $sessions = new $this->sessionInformationIteratorClass();
+
+        foreach ($this->sessionRegistryStorage->getSessionIds($user) as $sessionId) {
+            if ($sessionInformation = $this->getSessionInformation($sessionId)) {
+                if ($includeExpiredSessions === true || $sessionInformation->isExpired() === false) {
+                    $sessions->add($sessionInformation);
+                }
+            }
+        }
+
+        return $sessions;
+    }
+
+    /**
+     * Obtains the session information for the specified sessionId.
+     *
+     * @param string $sessionId the session identifier key.
+     * @return SessionInformation $sessionInformation
+     */
+    public function getSessionInformation($sessionId)
+    {
+        return $this->sessionRegistryStorage->getSessionInformation($sessionId);
+    }
+
+    /**
+     * Sets a SessionInformation object.
+     *
+     * @param SessionInformation $sessionInformation
+     * @return void
+     */
+    public function setSessionInformation(SessionInformation $sessionInformation)
+    {
+        $this->sessionRegistryStorage->setSessionInformation($sessionInformation->getSessionId(), $sessionInformation);
+    }
+
+    /**
+     * Updates the given sessionId so its last request time is equal to the present date and time.
+     *
+     * @param string $sessionId the session identifier key.
+     * @return void
+     */
+    public function refreshLastRequest($sessionId)
+    {
+        if ($sessionInformation = $this->getSessionInformation($sessionId)) {
+            $sessionInformation->refreshLastRequest();
+            $this->sessionRegistryStorage->setSessionInformation($sessionInformation);
+        }
+    }
+
+    /**
+     * Registers a new session for the specified user.
+     *
+     * @param string $sessionId the session identifier key.
+     * @param AccountInterface $user the specified user.
+     * @return void
+     */
+    public function registerNewSession($sessionId, AccountInterface $user)
+    {
+        $sessionInformation = new $this->sessionInformationClass($sessionId, $user);
+        $sessionInformation->refreshLastRequest();
+
+        $this->sessionRegistryStorage->setSessionInformation($sessionId, $sessionInformation);
+        $this->sessionRegistryStorage->addSessionId($sessionId, $user);
+    }
+
+    /**
+     * Deletes all the session information being maintained for the specified sessionId.
+     *
+     * @param string $sessionId the session identifier key.
+     * @param AccountInterface $user the specified user.
+     * @return void
+     */
+    public function removeSessionInformation($sessionId, AccountInterface $user)
+    {
+        $this->sessionRegistryStorage->removeSessionInformation($sessionId);
+        $this->sessionRegistryStorage->removeSessionId($sessionId, $user);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Session/SessionRegistryInterface.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionRegistryInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Session;
+
+/**
+ * SessionRegistryInterface.
+ *
+ * The SessionRegistry is used as the source of data on authenticated users and session data.
+ *
+ * @author Stefan Paschke <stefan.paschke@gmail.com>
+ */
+interface SessionRegistryInterface
+{
+    /**
+     * Obtains all the known users in the SessionRegistry.
+     */
+    function getAllUsers();
+
+    /**
+     * Obtains all the known sessions for the specified user.
+     */
+    function getAllSessions($user, $includeExpiredSessions = false);
+
+    /**
+     * Obtains the session information for the specified sessionId.
+     */
+    function getSessionInformation($sessionId);
+
+    /**
+     * Updates the given sessionId so its last request time is equal to the present date and time.
+     */
+    function refreshLastRequest($sessionId);
+
+    /**
+     * Registers a new session for the specified principal.
+     */
+    function registerNewSession($sessionId, $user);
+
+    /**
+     * Deletes all the session information being maintained for the specified sessionId.
+     */
+    function removeSessionInformation($sessionId, $user);
+}

--- a/src/Symfony/Component/Security/Http/Session/SessionRegistryStorageInterface.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionRegistryStorageInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Session;
+
+use Symfony\Component\Security\Core\User\AccountInterface;
+
+/**
+ * SessionRegistryStorageInterface.
+ *
+ * Stores the SessionInformation instances maintained in the SessionRegistry.
+ *
+ * @author Stefan Paschke <stefan.paschke@gmail.com>
+ */
+interface SessionRegistryStorageInterface
+{
+    /**
+     * Obtains all the users for which session information is stored.
+     *
+     * @return array An array of AccountInterface objects.
+     */
+    function getUsers();
+
+    /**
+     * Obtains all the known session IDs for the specified user.
+     *
+     * @param AccountInterface $user
+     * @return array an array ob session identifiers.
+     */
+    function getSessionIds(AccountInterface $user);
+
+    /**
+     * Adds one session ID to the specified users array
+     *
+     * @param string $sessionId the session identifier key.
+     * @param AccountInterface $user
+     * @return void
+     */
+    function addSessionId($sessionId, AccountInterface $user);
+
+    /**
+     * Removes one session ID from the specified users array.
+     *
+     * @param string $sessionId the session identifier key.
+     * @param AccountInterface $user
+     * @return void
+     */
+    function removeSessionId($sessionId, AccountInterface $user);
+
+    /**
+     * Obtains the maintained information for one session.
+     *
+     * @param string $sessionId the session identifier key.
+     * @return SessionInformation a SessionInformation object.
+     */
+    function getSessionInformation($sessionId);
+
+    /**
+     * Adds information for one session.
+     *
+     * @param string $sessionId the session identifier key.
+     * @param SessionInformation a SessionInformation object.
+     * @return void
+     */
+    function setSessionInformation($sessionId, SessionInformation $sessionInformation);
+
+    /**
+     * Deletes the maintained information of one session.
+     *
+     * @param string $sessionId the session identifier key.
+     * @return void
+     */
+    function removeSessionInformation($sessionId);
+}


### PR DESCRIPTION
This adds a ConcurrentSessionControlStrategy to the Symfony\Component\Security\Http\Session namespace.
It will enable the management of multiple sessions for the same user as described in 
http://static.springsource.org/spring-security/site/docs/3.0.x/apidocs/index.html?org/springframework/security/web/authentication/session/package-summary.html

The strategy requires a SessionRegistry and a ManageableSessionStorage, which are described in 

Symfony\Component\Security\Http\Session\SessionRegistryInterface
Symfony\Component\HttpFoundation\SessionStorage\ManageableSessionStorageInterface 
