### PR TITLE
ContainerBuilder: Prevent self-referencing aliases

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -427,6 +427,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             throw new \InvalidArgumentException('$id must be a string, or an Alias object.');
         }
 
+        if ($alias === strtolower($id)) {
+            throw new \InvalidArgumentException('An alias can not reference itself, got a circular reference on "'.$alias.'".');
+        }
+
         unset($this->definitions[$alias]);
 
         $this->aliases[$alias] = $id;


### PR DESCRIPTION
As it was, if you setAlias('a', 'a'); the compiler pass resolving it will go into an endless while loop.
