### PR TITLE
Fixed missing argument

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -229,7 +229,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->successHandler) {
-            $response = $this->successHandler->onAuthenticationSuccess($request, $token);
+            $response = $this->successHandler->onAuthenticationSuccess($event, $request, $token);
         } else {
             $response = new Response();
             $path = $this->determineTargetUrl($request);


### PR DESCRIPTION
Fixed missed argument in call custom handler when authentication is successful.
