### PR TITLE
[Security] made SecurityContext::vote() not final

### DIFF
--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -45,7 +45,7 @@ class SecurityContext implements SecurityContextInterface
         $this->alwaysAuthenticate = $alwaysAuthenticate;
     }
 
-    public final function vote($attributes, $object = null)
+    public function vote($attributes, $object = null)
     {
         if (null === $this->token) {
             throw new AuthenticationCredentialsNotFoundException('The security context contains no authentication token.');


### PR DESCRIPTION
How can we mock this method if there's the final keyword ?
