### PR TITLE
[FrameworkBundle] Ensure the test session listener is called late

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -23,10 +23,10 @@
         <service id="test.client.history" class="%test.client.history.class%" scope="prototype" />
 
         <service id="test.client.cookiejar" class="%test.client.cookiejar.class%" scope="prototype" />
-        
+
         <service id="test.session.listener" class="%test.session.listener.class%">
             <tag name="kernel.listener" event="core.request" method="handle" />
-            <tag name="kernel.listener" event="core.response" method="filter" />
+            <tag name="kernel.listener" event="core.response" method="filter" priority="-128" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
We want to persist the session after other listeners have set values to the session.
