### PR TITLE
[Security] Add providerKey to PreAuthenticatedToken tokens constructed by PreAuthenticatedAuthenticationProvider

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
@@ -68,7 +68,7 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
 
         $this->accountChecker->checkPostAuth($user);
 
-        return new PreAuthenticatedToken($user, $token->getCredentials(), $user->getRoles());
+        return new PreAuthenticatedToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles());
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -58,6 +58,7 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
         $token = $provider->authenticate($this->getSupportedToken('fabien', 'pass'));
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', $token);
         $this->assertEquals('pass', $token->getCredentials());
+        $this->assertEquals('key', $token->getProviderKey());
         $this->assertEquals(array(), $token->getRoles());
         $this->assertSame($user, $token->getUser());
     }


### PR DESCRIPTION
The omission of the providerKey was leading to endless ProviderNotFoundExceptions for pre-auth providers.  I noticed this affecting my LdapBundle, and it was likely also disrupting CasBundle and the X509 listener.
