### PR TITLE
Xmlloader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -271,7 +271,7 @@ class XmlFileLoader extends FileLoader
 
         // anonymous services as arguments
         if (false === $nodes = $xml->xpath('//container:argument[@type="service"][not(@id)]')) {
-            return;
+            return $xml;
         }
         foreach ($nodes as $node) {
             // give it a unique name
@@ -283,7 +283,7 @@ class XmlFileLoader extends FileLoader
 
         // anonymous services "in the wild"
         if (false === $nodes = $xml->xpath('//container:services/container:service[not(@id)]')) {
-            return;
+            return $xml;
         }
         foreach ($nodes as $node) {
             // give it a unique name


### PR DESCRIPTION
This fixes an issue when no anonymous services are found as this method needs to return the xml data because of `$xml = $this->processAnonymousServices($xml, $file);`
