### PR TITLE
Fix json template error.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.json.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.json.twig
@@ -1,1 +1,1 @@
-{{ { 'error': { 'code': status_code, 'message': status_text } }|json_encode }}
+{{ { 'error': { 'code': status_code, 'message': status_text } }|json_encode |raw }}


### PR DESCRIPTION
JSON template is not properly escaped.

`{&quot;error&quot;:{&quot;code&quot;:404,&quot;message&quot;:&quot;Not Found&quot;}}`

{"error":{"code":404,"message":"Not Found"}}
