### PR TITLE
Bundle::registerCommands namespace fix

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -149,7 +149,11 @@ abstract class Bundle extends ContainerAware implements BundleInterface
 
         $prefix = $this->getNamespace().'\\Command';
         foreach ($finder as $file) {
-            $r = new \ReflectionClass($prefix.strtr($file->getRelativePath(), '/', '\\').'\\'.$file->getBasename('.php'));
+            $ns = $prefix;
+            if ($relativePath = $file->getRelativePath()) {
+                $ns .= '\\'.strtr($relativePath, '/', '\\');
+            }
+            $r = new \ReflectionClass($ns.'\\'.$file->getBasename('.php'));
             if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract()) {
                 $application->add($r->newInstance());
             }


### PR DESCRIPTION
Add a namespace separator to the reflection class for console commands in `Command` sub-directories.

This fixes a bug in `Bundle::registerCommands` with console commands in sub-directories of `Command`. `MyBundle\Command\FooCommand` worked great, but with `MyBundle\Command\Bar\BazCommand` Bundle would try to register `MyBundle\CommandBar\BazCommand` instead.
