### PR TITLE
Sql lite fix

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
@@ -156,7 +156,10 @@ class SqliteProfilerStorage implements ProfilerStorageInterface
                 $stmt->bindValue($arg, $val, is_int($val) ? \SQLITE3_INTEGER : \SQLITE3_TEXT);
             }
 
-            $res = $stmt->execute();
+            $res = @$stmt->execute();
+            if (!$res) {
+                throw new \RuntimeException(sprintf('Error executing SQLite query "%s"', $query));
+            }
             $res->finalize();
         } else {
             foreach ($args as $arg => $val) {


### PR DESCRIPTION
Without this fix, I get these errors:

Warning: SQLite3Stmt::execute() [sqlite3stmt.execute]: Unable to execute statement: constraint failed in /Users/jseverson/Sites/exercise/vendor/symfony/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php on line 164

Fatal error: Call to a member function finalize() on a non-object in /Users/jseverson/Sites/exercise/vendor/symfony/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php on line 165
503 Service Unavailable
