### PR TITLE
Yaml parse

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -167,7 +167,7 @@ class Parser
                     $value = Inline::load($this->lines[0]);
                     if (is_array($value)) {
                         $first = reset($value);
-                        if ('*' === substr($first, 0, 1)) {
+                        if (is_string($first) && '*' === substr($first, 0, 1)) {
                             $data = array();
                             foreach ($value as $alias) {
                                 $data[] = $this->refs[substr($alias, 1)];


### PR DESCRIPTION
Here's the test script that triggered the warning, I'm not really sure what that code does, but it seemed to parse just fine before, just the assumption that it was a string was creating the warning.

```
    $data = array(
        'columns'   => array(
            'test'      => 123
        )
    );

    $d = new \Symfony\Component\Yaml\Dumper;
    $dm = $d->dump($data);

    $p = new \Symfony\Component\Yaml\Parser;
    $y = $p->parse($dm);

    var_dump($data, $dm, $y);die;
```
