### PR TITLE
Assetic: Bundle notation

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
@@ -30,13 +30,13 @@ class AssetFactory extends BaseAssetFactory
         parent::__construct($baseDir, $debug);
     }
 
-    protected function parseAsset($sourceUrl)
+    protected function parseInput($input)
     {
         // expand bundle notation
-        if ('@' == $sourceUrl[0] && false !== strpos($sourceUrl, '/')) {
-            $sourceUrl = $this->kernel->locateResource($sourceUrl);
+        if ('@' == $input[0] && false !== strpos($input, '/')) {
+            $input = $this->kernel->locateResource($input);
         }
 
-        return parent::parseAsset($sourceUrl);
+        return parent::parseInput($input);
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/Tests/FunctionalTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/FunctionalTest.php
@@ -85,7 +85,7 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $content = $container->get('templating')->render('::layout.html.twig');
         $crawler = new Crawler($content);
 
-        $this->assertEquals(2, count($crawler->filter('link[href$=".css"]')));
+        $this->assertEquals(3, count($crawler->filter('link[href$=".css"]')));
         $this->assertEquals(2, count($crawler->filter('script[src$=".js"]')));
     }
 
@@ -103,14 +103,14 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
         $content = $container->get('templating')->render('::layout.html.php');
         $crawler = new Crawler($content);
 
-        $this->assertEquals(2, count($crawler->filter('link[href$=".css"]')));
+        $this->assertEquals(3, count($crawler->filter('link[href$=".css"]')));
         $this->assertEquals(2, count($crawler->filter('script[src$=".js"]')));
     }
 
     public function provideDebugAndAssetCount()
     {
         return array(
-            array(true, 4),
+            array(true, 5),
             array(false, 2),
         );
     }

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/TestBundle.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/TestBundle.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Kernel;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class TestBundle extends Bundle
+{
+    public function getPath()
+    {
+        return parent::getPath().'/bundle';
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/TestKernel.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/TestKernel.php
@@ -27,6 +27,7 @@ class TestKernel extends Kernel
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \Symfony\Bundle\AsseticBundle\AsseticBundle(),
+            new TestBundle(),
         );
     }
 

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/bundle/Resources/css/bundle.css
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/bundle/Resources/css/bundle.css
@@ -1,0 +1,1 @@
+/* bundle.css */

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/views/layout.html.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/views/layout.html.php
@@ -1,7 +1,7 @@
 <?php $view->extend('::base.html.php') ?>
 
 <?php $view['slots']->start('stylesheets') ?>
-    <?php foreach($view['assetic']->stylesheets('stylesheet1.css, stylesheet2.css') as $url): ?>
+    <?php foreach($view['assetic']->stylesheets('stylesheet1.css, stylesheet2.css, @TestBundle/Resources/css/bundle.css') as $url): ?>
         <link href="<?php echo $view->escape($url) ?>" type="text/css" rel="stylesheet" />
     <?php endforeach; ?>
 <?php $view['slots']->stop() ?>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/views/layout.html.twig
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Kernel/views/layout.html.twig
@@ -1,7 +1,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-    {% stylesheets 'stylesheet1.css' 'stylesheet2.css' %}
+    {% stylesheets 'stylesheet1.css' 'stylesheet2.css' '@TestBundle/Resources/css/bundle.css' %}
         <link href="{{ asset_url }}" type="text/css" rel="stylesheet" />
     {% endstylesheets %}
 {% endblock %}


### PR DESCRIPTION
This fixes the parsing of bundle notation in templating tags, for example:

```
{% javascripts '@MyBundle/Resources/javascripts/main.js' %}
<script src="{{ asset_url }}"></script>
{% endjavascripts %}
```
