### PR TITLE
Security catch PDOException

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -88,8 +88,8 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
             return $user;
         } catch (UsernameNotFoundException $notFound) {
             throw $notFound;
-        } catch (\PDOException $pdo) {
-            throw $pdo;
+        } catch (\RuntimeException $runtime) {
+            throw $runtime;
         } catch (\Exception $repositoryProblem) {
             throw new AuthenticationServiceException($repositoryProblem->getMessage(), $token, 0, $repositoryProblem);
         }


### PR DESCRIPTION
Throw PDOException if the database have a problem

By example, if the database is down, PDO return an PDOException.
