### PR TITLE
Config path

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -293,6 +293,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
         if (null !== $this->prototype) {
             foreach ($value as $k => $v) {
+                $this->prototype->setName($k);
                 try {
                     $value[$k] = $this->prototype->finalize($v);
                 } catch (UnsetKeyException $unset) {


### PR DESCRIPTION
This fixes the path for the finalization error when using a prototype.

Without this the given path always uses the name of the last entry of the prototype due to the `foreach` in the normalization.
