### PR TITLE
Code coverage fix

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <directory>./src/Symfony/</directory>
             <exclude>
                 <directory>./src/Symfony/Bundle/*/Resources</directory>
+                <directory>./src/Symfony/Bundle/*/Tests</directory>
                 <directory>./src/Symfony/Component/*/Resources</directory>
             </exclude>
         </whitelist>


### PR DESCRIPTION
I feel like it doesn't make sense to generate code coverage for the Tests directories within each Bundle, because that is the test code itself. Normally, tests are in a separate tree so this isn't an issue. But with the built-in Bundles, that is not the case.
