### PR TITLE
Swiftmailer

### DIFF
--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -63,6 +63,10 @@ class SwiftmailerExtension extends Extension
             $transport = $config['transport'];
         }
 
+        if ('smtp' === $transport) {
+            $loader->load('smtp.xml');
+        }
+
         $container->setParameter('swiftmailer.transport.name', $transport);
 
         $container->setAlias('swiftmailer.transport', 'swiftmailer.transport.'.$transport);
@@ -79,10 +83,10 @@ class SwiftmailerExtension extends Extension
         if (isset($config['spool'])) {
             $type = $config['spool']['type'];
 
+            $loader->load('spool.xml');
             $container->setAlias('swiftmailer.transport.real', 'swiftmailer.transport.'.$transport);
             $container->setAlias('swiftmailer.transport', 'swiftmailer.transport.spool');
             $container->setAlias('swiftmailer.spool', 'swiftmailer.spool.'.$type);
-            $container->getDefinition('swiftmailer.spool.file')->setArgument(0, '%swiftmailer.spool.file.path%');
 
             foreach (array('path') as $key) {
                 $container->setParameter('swiftmailer.spool.'.$type.'.'.$key, $config['spool'][$key]);

--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/smtp.xml
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/smtp.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://www.symfony-project.org/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
+
+  <parameters>
+    <parameter key="swiftmailer.transport.smtp.class">Swift_Transport_EsmtpTransport</parameter>
+  </parameters>
+
+  <services>
+    <service id="swiftmailer.transport.smtp" class="%swiftmailer.transport.smtp.class%" public="false">
+      <argument type="service" id="swiftmailer.transport.buffer" />
+      <argument type="collection">
+        <argument type="service" id="swiftmailer.transport.authhandler" />
+      </argument>
+      <argument type="service" id="swiftmailer.transport.eventdispatcher" />
+
+      <call method="setHost"><argument>%swiftmailer.transport.smtp.host%</argument></call>
+      <call method="setPort"><argument>%swiftmailer.transport.smtp.port%</argument></call>
+      <call method="setEncryption"><argument>%swiftmailer.transport.smtp.encryption%</argument></call>
+      <call method="setUsername"><argument>%swiftmailer.transport.smtp.username%</argument></call>
+      <call method="setPassword"><argument>%swiftmailer.transport.smtp.password%</argument></call>
+      <call method="setAuthMode"><argument>%swiftmailer.transport.smtp.auth_mode%</argument></call>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/spool.xml
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/spool.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://www.symfony-project.org/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
+
+  <parameters>
+    <parameter key="swiftmailer.spool.file.class">Swift_FileSpool</parameter>
+
+    <parameter key="swiftmailer.plugin.redirecting.class">Swift_Plugins_RedirectingPlugin</parameter>
+    <parameter key="swiftmailer.plugin.blackhole.class">Swift_Plugins_BlackholePlugin</parameter>
+  </parameters>
+
+  <services>
+    <service id="swiftmailer.transport.spool" class="Swift_Transport_SpoolTransport" public="false">
+      <argument type="service" id="swiftmailer.transport.eventdispatcher" />
+      <argument type="service" id="swiftmailer.spool" />
+    </service>
+
+    <service id="swiftmailer.spool.file" class="%swiftmailer.spool.file.class%" public="false">
+      <argument>%swiftmailer.spool.file.path%</argument>
+    </service>
+
+    <service id="swiftmailer.spool" alias="swiftmailer.spool.file" public="false" />
+  </services>
+</container>

--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/swiftmailer.xml
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/swiftmailer.xml
@@ -7,12 +7,10 @@
   <parameters>
     <parameter key="swiftmailer.class">Swift_Mailer</parameter>
 
-    <parameter key="swiftmailer.transport.smtp.class">Swift_Transport_EsmtpTransport</parameter>
     <parameter key="swiftmailer.transport.sendmail.class">Swift_Transport_SendmailTransport</parameter>
     <parameter key="swiftmailer.transport.mail.class">Swift_Transport_MailTransport</parameter>
 
     <parameter key="swiftmailer.transport.failover.class">Swift_Transport_FailoverTransport</parameter>
-    <parameter key="swiftmailer.spool.file.class">Swift_FileSpool</parameter>
 
     <parameter key="swiftmailer.init_file">%swiftmailer.base_dir%/swift_init.php</parameter>
 
@@ -24,21 +22,6 @@
     <service id="swiftmailer.mailer" class="%swiftmailer.class%" public="false">
       <argument type="service" id="swiftmailer.transport" />
       <file>%swiftmailer.init_file%</file>
-    </service>
-
-    <service id="swiftmailer.transport.smtp" class="%swiftmailer.transport.smtp.class%" public="false">
-      <argument type="service" id="swiftmailer.transport.buffer" />
-      <argument type="collection">
-        <argument type="service" id="swiftmailer.transport.authhandler" />
-      </argument>
-      <argument type="service" id="swiftmailer.transport.eventdispatcher" />
-
-      <call method="setHost"><argument>%swiftmailer.transport.smtp.host%</argument></call>
-      <call method="setPort"><argument>%swiftmailer.transport.smtp.port%</argument></call>
-      <call method="setEncryption"><argument>%swiftmailer.transport.smtp.encryption%</argument></call>
-      <call method="setUsername"><argument>%swiftmailer.transport.smtp.username%</argument></call>
-      <call method="setPassword"><argument>%swiftmailer.transport.smtp.password%</argument></call>
-      <call method="setAuthMode"><argument>%swiftmailer.transport.smtp.auth_mode%</argument></call>
     </service>
 
     <service id="swiftmailer.transport.sendmail" class="%swiftmailer.transport.sendmail.class%" public="false">
@@ -71,17 +54,8 @@
 
     <service id="swiftmailer.transport.replacementfactory" class="Swift_StreamFilters_StringReplacementFilterFactory" public="false" />
 
-    <service id="swiftmailer.transport.spool" class="Swift_Transport_SpoolTransport" public="false">
-      <argument type="service" id="swiftmailer.transport.eventdispatcher" />
-      <argument type="service" id="swiftmailer.spool" />
-    </service>
-
     <service id="swiftmailer.transport.null" class="Swift_Transport_NullTransport" public="false">
       <argument type="service" id="swiftmailer.transport.eventdispatcher" />
-    </service>
-
-    <service id="swiftmailer.spool.file" class="%swiftmailer.spool.file.class%" public="false">
-      <argument />
     </service>
 
     <service id="swiftmailer.plugin.redirecting" class="%swiftmailer.plugin.redirecting.class%" public="false">
@@ -91,7 +65,5 @@
     <service id="swiftmailer.plugin.blackhole" class="%swiftmailer.plugin.blackhole.class%" public="false" />
 
     <service id="swiftmailer.transport" alias="swiftmailer.transport.smtp" public="false" />
-
-    <service id="swiftmailer.spool" alias="swiftmailer.spool.file" public="false" />
   </services>
 </container>


### PR DESCRIPTION
This refactors the swiftmailer configuration to load the smtp transport only when it is needed. The way the parameters are set currently (setting them to `'swiftmailer.transport.'.$transport.$key` throws an error when using another transport.

Another way to fix it would be to define the parameters as `'swiftmailer.transport.smtp.'.$key` as they are not used for other transports.
