### PR TITLE
Added PdoProfilerStorage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -198,6 +198,19 @@ class FrameworkExtension extends Extension
             $container->setParameter('profiler_listener.only_exceptions', $config['only_exceptions']);
         }
 
+        if (isset($config['profiler']['storage_id'])) {
+            $container->setAlias('profiler.storage', 'profiler.storage.'.$config['profiler']['storage_id']);
+        }
+        if (isset($config['profiler']['pdo']['dsn'])) {
+            $container->setParameter('profiler.storage.pdo.dsn', $config['profiler']['pdo']['dsn']);
+        }
+        if (isset($config['profiler']['pdo']['username'])) {
+            $container->setParameter('profiler.storage.pdo.username', $config['profiler']['pdo']['username']);
+        }
+        if (isset($config['profiler']['pdo']['password'])) {
+            $container->setParameter('profiler.storage.pdo.password', $config['profiler']['pdo']['password']);
+        }
+
         if (isset($config['matcher'])) {
             if (isset($config['matcher']['service'])) {
                 $container->setAlias('profiler.request_matcher', $config['matcher']['service']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -8,6 +8,9 @@
         <parameter key="profiler.class">Symfony\Component\HttpKernel\Profiler\Profiler</parameter>
         <parameter key="profiler.storage.sqlite.class">Symfony\Component\HttpKernel\Profiler\SqliteProfilerStorage</parameter>
         <parameter key="profiler.storage.pdo.class">Symfony\Component\HttpKernel\Profiler\PdoProfilerStorage</parameter>
+        <parameter key="profiler.storage.pdo.dsn">mysql:host=localhost;dbname=sf_profiler</parameter>
+        <parameter key="profiler.storage.pdo.username">root</parameter>
+        <parameter key="profiler.storage.pdo.password"></parameter>
         <parameter key="profiler.storage.file">%kernel.cache_dir%/profiler.db</parameter>
         <parameter key="profiler.storage.lifetime">86400</parameter>
         <parameter key="profiler_listener.class">Symfony\Bundle\FrameworkBundle\Profiler\ProfilerListener</parameter>
@@ -26,7 +29,7 @@
         </service>
 
         <service id="profiler.storage.pdo" class="%profiler.storage.pdo.class%" public="false">
-            <argument type="service" id="pdo_connection" />
+            <argument type="service" id="profiler.storage.pdo_connection"/>
             <argument>%profiler.storage.lifetime%</argument>
         </service>
 
@@ -38,6 +41,13 @@
             <argument>%profiler_listener.only_exceptions%</argument>
         </service>
 
+        <service id="profiler.storage.pdo_connection" class="PDO" public="false">
+          <argument>%profiler.storage.pdo.dsn%</argument>
+          <argument>%profiler.storage.pdo.username%</argument>
+          <argument>%profiler.storage.pdo.password%</argument>
+        </service>
+
         <service id="profiler.storage" alias="profiler.storage.sqlite" public="false" />
+        
     </services>
 </container>

--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -20,7 +20,16 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
  */
 class PdoProfilerStorage implements ProfilerStorageInterface
 {
+    /**
+     *
+     * @var \PDO The PDO object
+     */
     protected $db;
+
+    /**
+     *
+     * @var integer The lifetime to use for the purge
+     */
     protected $lifetime;
 
     /**
@@ -101,7 +110,6 @@ class PdoProfilerStorage implements ProfilerStorageInterface
 
         return $status;
     }
-
     /**
      * {@inheritdoc}
      */
@@ -119,7 +127,9 @@ class PdoProfilerStorage implements ProfilerStorageInterface
 
     protected function initDb()
     {
-        $db->exec('CREATE TABLE IF NOT EXISTS data (token STRING, data STRING, ip STRING, url STRING, time INTEGER, parent STRING, created_at INTEGER)');
+        $db = $this->db;
+
+        $db->exec('CREATE TABLE IF NOT EXISTS data (token char(32), data TEXT, ip varchar(255), url varchar(255), time INTEGER, parent varchar(255), created_at INTEGER)');
         $db->exec('CREATE INDEX IF NOT EXISTS data_created_at ON data (created_at)');
         $db->exec('CREATE INDEX IF NOT EXISTS data_ip ON data (ip)');
         $db->exec('CREATE INDEX IF NOT EXISTS data_url ON data (url)');


### PR DESCRIPTION
The SqliteProfilerStorage, which is the default storage, works fine and fast, but when receiving multiple concurrent requets, it fails due to file locking and it becomes really annoying. This is very common for AJAX powered websites.

The PdoProfilerStorage allows to store profiling information in PDO supported databases like MySQL. To enable it follow these simple steps: 

1) create the database in the server, the default name is sf_profiler. It can be changed in the dsn configuration below.

2) configure PdoProfilerStorage by adding these lines to config_dev.yml:

app.config:
    profiler:
      only_exceptions: false
      storage_id: pdo
      pdo:
        dsn: mysql:host=localhost;dbname=sf_profiler
        username: root
        password: yourpassword

3) enjoy!
