### PR TITLE
[Security] Remove extra scriptName

### DIFF
--- a/src/Symfony/Component/Security/Http/EntryPoint/RetryAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/RetryAuthenticationEntryPoint.php
@@ -51,7 +51,7 @@ class RetryAuthenticationEntryPoint implements AuthenticationEntryPointInterface
             $qs = '?'.$qs;
         }
 
-        $url = $scheme.'://'.$request->getHost().$port.$request->getScriptName().$request->getPathInfo().$qs;
+        $url = $scheme.'://'.$request->getHost().$port.$request->getPathInfo().$qs;
 
         return new RedirectResponse($url, 301);
     }


### PR DESCRIPTION
Remove extra "getScriptName" method call while construct redirect URL for https.
In my opinion it does not needed, because of .htaccess contain next lines:
<IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteCond %{REQUEST_FILENAME} !-f
    RewriteRule ^(.*)$ app.php [QSA,L]
</IfModule>

If leave "getScriptName" method call, result of redirect will be next:
https://www.example.com/app.php/login
