### PR TITLE
Issue for XPathExprOr: missing prefix in string conversion

### DIFF
--- a/src/Symfony/Component/CssSelector/XPathExprOr.php
+++ b/src/Symfony/Component/CssSelector/XPathExprOr.php
@@ -42,7 +42,7 @@ class XPathExprOr extends XPathExpr
      */
     public function __toString()
     {
-        $prefix = $this->prefix;
+        $prefix = $this->getPrefix();
 
         $tmp = array();
         foreach ($this->items as $i) {

--- a/tests/Symfony/Tests/Component/CssSelector/Node/OrNodeTest.php
+++ b/tests/Symfony/Tests/Component/CssSelector/Node/OrNodeTest.php
@@ -26,4 +26,18 @@ class OrNodeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("h1 | h2 | h3", (string) $or->toXpath(), '->toXpath() returns the xpath representation of the node');
     }
+    
+    public function testIssueMissingPrefix()
+    {
+        // h1, h2, h3
+        $element1 = new ElementNode('*', 'h1');
+        $element2 = new ElementNode('*', 'h2');
+        $element3 = new ElementNode('*', 'h3');
+        $or = new OrNode(array($element1, $element2, $element3));
+        
+        $xPath = $or->toXPath();
+        $xPath->addPrefix('descendant-or-self::');
+
+        $this->assertEquals("descendant-or-self::h1 | descendant-or-self::h2 | descendant-or-self::h3", (string) $xPath);
+    }
 }


### PR DESCRIPTION
Hi there,

I hope it's right to send the pull request to you. I also created a small and dumb test for the issue. I looked at the original implementation and i think the problem is, that you use private properties in the parent class for xPathExprOr. so that you cannot access the prefix with $this->prefix in it.
However I think the distribution for the prefix should be put in the parts of the or-sub-expressions the way it is shown in the test.

Hope this helps.

Best regards
Philipp
