### PR TITLE
Translation

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -167,7 +167,7 @@ class Translator implements TranslatorInterface
 
     private function optimizeCatalogue($locale)
     {
-        if (strlen($locale) > 3) {
+        if (strrchr($locale, '_') !== false) {
             $fallback = substr($locale, 0, -strlen(strrchr($locale, '_')));
         } else {
             $fallback = $this->fallbackLocale;


### PR DESCRIPTION
Fixed fallback location if location is longer than three characters (possibly by mistake). I ran into this problem when I used the SILEX framework.
