### PR TITLE
URL to SimonSapin/CSSSelect Github page fixed.

### DIFF
--- a/src/Symfony/Component/CssSelector/README.md
+++ b/src/Symfony/Component/CssSelector/README.md
@@ -35,7 +35,7 @@ Resources
 This component is a port of the Python lxml library, which is copyright Infrae
 and distributed under the BSD license.
 
-Current code is a port of https://github.com/SimonSapin/cssselect@v0.7.1
+Current code is a port of https://github.com/SimonSapin/cssselect/tree/v0.7.1
 
 You can run the unit tests with the following command:
 


### PR DESCRIPTION
Changed `https://github.com/SimonSapin/cssselect@v0.7.1` to `https://github.com/SimonSapin/cssselect/tree/v0.7.1`.
