### PR TITLE
[ExpressionLanguage] dont escape identifiers

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
@@ -20,8 +20,11 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  */
 class ConstantNode extends Node
 {
-    public function __construct($value)
+    private $isIdentifier;
+
+    public function __construct($value, $isIdentifier = false)
     {
+        $this->isIdentifier = $isIdentifier;
         parent::__construct(
             array(),
             array('value' => $value)
@@ -43,7 +46,9 @@ class ConstantNode extends Node
         $array = array();
         $value = $this->attributes['value'];
 
-        if (true === $value) {
+        if ($this->isIdentifier) {
+            $array[] = $value;
+        } elseif (true === $value) {
             $array[] = 'true';
         } elseif (false === $value) {
             $array[] = 'false';

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -39,7 +39,7 @@ class GetAttrNode extends Node
                 $compiler
                     ->compile($this->nodes['node'])
                     ->raw('->')
-                    ->raw($this->nodes['attribute']->attributes['name'])
+                    ->raw($this->nodes['attribute']->attributes['value'])
                 ;
                 break;
 
@@ -47,7 +47,7 @@ class GetAttrNode extends Node
                 $compiler
                     ->compile($this->nodes['node'])
                     ->raw('->')
-                    ->raw($this->nodes['attribute']->attributes['name'])
+                    ->raw($this->nodes['attribute']->attributes['value'])
                     ->raw('(')
                     ->compile($this->nodes['arguments'])
                     ->raw(')')
@@ -73,7 +73,7 @@ class GetAttrNode extends Node
                     throw new \RuntimeException('Unable to get a property on a non-object.');
                 }
 
-                $property = $this->nodes['attribute']->attributes['name'];
+                $property = $this->nodes['attribute']->attributes['value'];
 
                 return $obj->$property;
 
@@ -83,7 +83,7 @@ class GetAttrNode extends Node
                     throw new \RuntimeException('Unable to get a property on a non-object.');
                 }
 
-                return call_user_func_array(array($obj, $this->nodes['attribute']->attributes['name']), $this->nodes['arguments']->evaluate($functions, $values));
+                return call_user_func_array(array($obj, $this->nodes['attribute']->attributes['value']), $this->nodes['arguments']->evaluate($functions, $values));
 
             case self::ARRAY_CALL:
                 $array = $this->nodes['node']->evaluate($functions, $values);

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -330,7 +330,7 @@ class Parser
                     throw new SyntaxError('Expected name', $token->cursor);
                 }
 
-                $arg = new Node\ConstantNode($token->value);
+                $arg = new Node\ConstantNode($token->value, true);
 
                 $arguments = new Node\ArgumentsNode();
                 if ($this->stream->current->test(Token::PUNCTUATION_TYPE, '(')) {

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -330,7 +330,7 @@ class Parser
                     throw new SyntaxError('Expected name', $token->cursor);
                 }
 
-                $arg = new Node\NameNode($token->value);
+                $arg = new Node\ConstantNode($token->value);
 
                 $arguments = new Node\ArgumentsNode();
                 if ($this->stream->current->test(Token::PUNCTUATION_TYPE, '(')) {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConstantNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/ConstantNodeTest.php
@@ -50,6 +50,7 @@ class ConstantNodeTest extends AbstractNodeTest
             array('3', new ConstantNode(3)),
             array('3.3', new ConstantNode(3.3)),
             array('"foo"', new ConstantNode('foo')),
+            array('foo', new ConstantNode('foo', true)),
             array('{0: 1, "b": "a", 1: true}', new ConstantNode(array(1, 'b' => 'a', true))),
             array('{"a\\"b": "c", "a\\\\b": "d"}', new ConstantNode(array('a"b' => 'c', 'a\\b' => 'd'))),
             array('["c", "d"]', new ConstantNode(array('c', 'd'))),

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -24,9 +24,9 @@ class GetAttrNodeTest extends AbstractNodeTest
             array('b', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), array('foo' => array('b' => 'a', 'b'))),
             array('a', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), array('foo' => array('b' => 'a', 'b'))),
 
-            array('bar', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
+            array('bar', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
 
-            array('baz', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
+            array('baz', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
             array('a', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL), array('foo' => array('b' => 'a', 'b'), 'index' => 'b')),
         );
     }
@@ -37,9 +37,9 @@ class GetAttrNodeTest extends AbstractNodeTest
             array('$foo[0]', new GetAttrNode(new NameNode('foo'), new ConstantNode(0), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)),
             array('$foo["b"]', new GetAttrNode(new NameNode('foo'), new ConstantNode('b'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)),
 
-            array('$foo->foo', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
+            array('$foo->foo', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::PROPERTY_CALL), array('foo' => new Obj())),
 
-            array('$foo->foo(array("b" => "a", 0 => "b"))', new GetAttrNode(new NameNode('foo'), new NameNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
+            array('$foo->foo(array("b" => "a", 0 => "b"))', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), array('foo' => new Obj())),
             array('$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)),
         );
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -98,24 +98,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 '(3 - 3) * 2',
             ),
             array(
-                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar'), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL),
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL),
                 'foo.bar',
                 array('foo'),
             ),
             array(
-                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar'), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar', true), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
                 'foo.bar()',
                 array('foo'),
             ),
             array(
-                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('not'), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('not', true), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
                 'foo.not()',
                 array('foo'),
             ),
             array(
                 new Node\GetAttrNode(
                     new Node\NameNode('foo'),
-                    new Node\ConstantNode('bar'),
+                    new Node\ConstantNode('bar', true),
                     $arguments,
                     Node\GetAttrNode::METHOD_CALL
                 ),
@@ -159,7 +159,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     private function createGetAttrNode($node, $item, $type)
     {
-        return new Node\GetAttrNode($node, new Node\ConstantNode($item), new Node\ArgumentsNode(), $type);
+        return new Node\GetAttrNode($node, new Node\ConstantNode($item, Node\GetAttrNode::ARRAY_CALL !== $type), new Node\ArgumentsNode(), $type);
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -98,24 +98,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 '(3 - 3) * 2',
             ),
             array(
-                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\NameNode('bar'), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL),
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar'), new Node\ArgumentsNode(), Node\GetAttrNode::PROPERTY_CALL),
                 'foo.bar',
                 array('foo'),
             ),
             array(
-                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\NameNode('bar'), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('bar'), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
                 'foo.bar()',
                 array('foo'),
             ),
             array(
-                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\NameNode('not'), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
+                new Node\GetAttrNode(new Node\NameNode('foo'), new Node\ConstantNode('not'), new Node\ArgumentsNode(), Node\GetAttrNode::METHOD_CALL),
                 'foo.not()',
                 array('foo'),
             ),
             array(
                 new Node\GetAttrNode(
                     new Node\NameNode('foo'),
-                    new Node\NameNode('bar'),
+                    new Node\ConstantNode('bar'),
                     $arguments,
                     Node\GetAttrNode::METHOD_CALL
                 ),
@@ -159,9 +159,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     private function createGetAttrNode($node, $item, $type)
     {
-        $attr = Node\GetAttrNode::ARRAY_CALL === $type ? new Node\ConstantNode($item) : new Node\NameNode($item);
-
-        return new Node\GetAttrNode($node, $attr, new Node\ArgumentsNode(), $type);
+        return new Node\GetAttrNode($node, new Node\ConstantNode($item), new Node\ArgumentsNode(), $type);
     }
 
     /**


### PR DESCRIPTION
So that dump works as expected for when dumping properties/methods.