### PR TITLE
[Tui] Fix quit keys not working when triggered via simulateInput()

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/ScreenBufferHtmlRenderer.php
+++ b/src/Symfony/Component/Tui/Ansi/ScreenBufferHtmlRenderer.php
@@ -55,7 +55,7 @@ final class ScreenBufferHtmlRenderer
 
         // Only include lines up to the last non-empty line
         if ($lastNonEmpty >= 0) {
-            $result = array_slice($result, 0, $lastNonEmpty + 1);
+            $result = \array_slice($result, 0, $lastNonEmpty + 1);
         } else {
             $result = [];
         }
@@ -106,7 +106,7 @@ final class ScreenBufferHtmlRenderer
                 $lastStyle = $style;
             }
 
-            $html .= htmlspecialchars($char, ENT_QUOTES | ENT_HTML5);
+            $html .= htmlspecialchars($char, \ENT_QUOTES | \ENT_HTML5);
         }
 
         if ($inSpan) {

--- a/src/Symfony/Component/Tui/Loop/FixedStepAccumulator.php
+++ b/src/Symfony/Component/Tui/Loop/FixedStepAccumulator.php
@@ -29,7 +29,7 @@ final class FixedStepAccumulator
         private int $maxStepsPerUpdate = 5,
     ) {
         if ($stepsPerSecond <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %s.', $stepsPerSecond));
+            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %d.', $stepsPerSecond));
         }
 
         if ($maxStepsPerUpdate < 1) {
@@ -60,7 +60,7 @@ final class FixedStepAccumulator
     public function setStepsPerSecond(float $stepsPerSecond): void
     {
         if ($stepsPerSecond <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %s.', $stepsPerSecond));
+            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %d.', $stepsPerSecond));
         }
 
         $this->stepsPerSecond = $stepsPerSecond;

--- a/src/Symfony/Component/Tui/Loop/PeriodicStepper.php
+++ b/src/Symfony/Component/Tui/Loop/PeriodicStepper.php
@@ -30,7 +30,7 @@ final class PeriodicStepper
         int $maxStepsPerUpdate = 8,
     ) {
         if ($intervalSeconds <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %s.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
         }
 
         $this->accumulator = new FixedStepAccumulator(1.0 / $intervalSeconds, $maxStepsPerUpdate);
@@ -60,7 +60,7 @@ final class PeriodicStepper
     public function setIntervalSeconds(float $intervalSeconds): void
     {
         if ($intervalSeconds <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %s.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
         }
 
         $this->intervalSeconds = $intervalSeconds;

--- a/src/Symfony/Component/Tui/Loop/TickScheduler.php
+++ b/src/Symfony/Component/Tui/Loop/TickScheduler.php
@@ -39,7 +39,7 @@ final class TickScheduler
     public function schedule(callable $callback, float $intervalSeconds): string
     {
         if ($intervalSeconds <= 0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %s.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
         }
 
         $id = 'interval-'.(++$this->counter);

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -174,7 +174,7 @@ final class Renderer implements WidgetRendererInterface
 
             $lineWidth = AnsiUtils::visibleWidth($line);
             if ($lineWidth > $availableColumns) {
-                throw new RenderException(\sprintf("Widget %s rendered line %d with width %d, exceeding the available %d columns.\nLine preview: %s", $widget::class, $i, $lineWidth, $availableColumns, mb_substr(AnsiUtils::stripAnsiCodes($line), 0, 100)), $i, $lineWidth, $availableColumns);
+                throw new RenderException(\sprintf("Widget "%s" rendered line %d with width %d, exceeding the available %d columns.\nLine preview: %d.", $widget::class, $i, $lineWidth, $availableColumns, mb_substr(AnsiUtils::stripAnsiCodes($line), 0, 100)), $i, $lineWidth, $availableColumns);
             }
         }
 

--- a/src/Symfony/Component/Tui/Render/ScreenWriter.php
+++ b/src/Symfony/Component/Tui/Render/ScreenWriter.php
@@ -383,7 +383,7 @@ final class ScreenWriter
                 $plainLine = preg_replace('/\x1b(?:\[[0-9;]*[a-zA-Z]|\][^\x07]*\x07)/', '', $line);
                 $preview = mb_substr($plainLine, 0, 100);
 
-                throw new RenderException(\sprintf("Rendered line %d exceeds terminal width (%d > %d).\nLine preview: %s%s", $i, $lineWidth, $width, $preview, mb_strlen($plainLine) > 100 ? '...' : ''), $i, $lineWidth, $width);
+                throw new RenderException(\sprintf("Rendered line %d exceeds terminal width (%d > %d).\nLine preview: %d%d.", $i, $lineWidth, $width, $preview, mb_strlen($plainLine) > 100 ? '...' : ''), $i, $lineWidth, $width);
             }
 
             $buffer .= $line;

--- a/src/Symfony/Component/Tui/Render/WidgetRect.php
+++ b/src/Symfony/Component/Tui/Render/WidgetRect.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Tui\Render;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final readonly class WidgetRect
+final class WidgetRect
 {
     public function __construct(
         private int $row,

--- a/src/Symfony/Component/Tui/Style/Border.php
+++ b/src/Symfony/Component/Tui/Style/Border.php
@@ -99,7 +99,7 @@ final class Border
             2 => new self($border[0], $border[1], $border[0], $border[1], $pattern, $color),
             3 => new self($border[0], $border[1], $border[2], $border[1], $pattern, $color),
             4 => new self($border[0], $border[1], $border[2], $border[3], $pattern, $color),
-            default => throw new InvalidArgumentException('Border array must have 1, 2, 3, or 4 elements'),
+            default => throw new InvalidArgumentException('Border array must have 1, 2, 3, or 4 elements.'),
         };
     }
 

--- a/src/Symfony/Component/Tui/Style/Border.php
+++ b/src/Symfony/Component/Tui/Style/Border.php
@@ -183,7 +183,7 @@ final class Border
         $chars = $pattern->getChars();
         $strategies = $pattern->getStrategies();
 
-        $outerStyle = $outerStyle ?? new Style();
+        $outerStyle ??= new Style();
         $borderColor = $this->color ?? $innerStyle->getColor();
 
         $lines = [];

--- a/src/Symfony/Component/Tui/Style/BorderPattern.php
+++ b/src/Symfony/Component/Tui/Style/BorderPattern.php
@@ -236,7 +236,7 @@ final class BorderPattern
             self::WIDE_MEDIUM => self::wideMedium(),
             self::TALL_LARGE => self::tallLarge(),
             self::WIDE_LARGE => self::wideLarge(),
-            default => throw new InvalidArgumentException(sprintf('Unknown border pattern "%s".', $style)),
+            default => throw new InvalidArgumentException(\sprintf('Unknown border pattern "%s".', $style)),
         };
     }
 

--- a/src/Symfony/Component/Tui/Style/Color.php
+++ b/src/Symfony/Component/Tui/Style/Color.php
@@ -81,7 +81,7 @@ final class Color
     {
         $name = strtolower($name);
         if (!isset(self::BASIC_COLORS[$name])) {
-            throw new InvalidArgumentException(\sprintf('Unknown color name: %s', $name));
+            throw new InvalidArgumentException(\sprintf('Unknown color name: "%s".', $name));
         }
 
         return new self(ColorType::Named, $name);
@@ -114,7 +114,7 @@ final class Color
         }
 
         if (6 !== \strlen($hex) || !ctype_xdigit($hex)) {
-            throw new InvalidArgumentException(\sprintf('Invalid hex color: %s', $hex));
+            throw new InvalidArgumentException(\sprintf('Invalid hex color: "%s".', $hex));
         }
 
         return new self(ColorType::Hex, $hex);

--- a/src/Symfony/Component/Tui/Style/Padding.php
+++ b/src/Symfony/Component/Tui/Style/Padding.php
@@ -82,7 +82,7 @@ final class Padding
             2 => new self($padding[0], $padding[1], $padding[0], $padding[1]),
             3 => new self($padding[0], $padding[1], $padding[2], $padding[1]),
             4 => new self($padding[0], $padding[1], $padding[2], $padding[3]),
-            default => throw new InvalidArgumentException('Padding array must have 1, 2, 3, or 4 elements'),
+            default => throw new InvalidArgumentException('Padding array must have 1, 2, 3, or 4 elements.'),
         };
     }
 

--- a/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
+++ b/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
@@ -104,7 +104,7 @@ final class ScreenBuffer
     public function write(string $data): void
     {
         $i = 0;
-        $len = strlen($data);
+        $len = \strlen($data);
 
         while ($i < $len) {
             $char = $data[$i];
@@ -165,7 +165,7 @@ final class ScreenBuffer
             }
 
             // Skip other control characters
-            if (ord($char) < 32 && "\x1b" !== $char) {
+            if (\ord($char) < 32 && "\x1b" !== $char) {
                 ++$i;
                 continue;
             }
@@ -200,7 +200,7 @@ final class ScreenBuffer
 
         // Only include lines up to the last non-empty line
         if ($lastNonEmpty >= 0) {
-            $result = array_slice($result, 0, $lastNonEmpty + 1);
+            $result = \array_slice($result, 0, $lastNonEmpty + 1);
         } else {
             $result = [];
         }
@@ -231,7 +231,7 @@ final class ScreenBuffer
 
         // Only include lines up to the last non-empty line
         if ($lastNonEmpty >= 0) {
-            $result = array_slice($result, 0, $lastNonEmpty + 1);
+            $result = \array_slice($result, 0, $lastNonEmpty + 1);
         } else {
             $result = [];
         }
@@ -353,7 +353,7 @@ final class ScreenBuffer
         }
 
         // Fill any gaps with spaces
-        for ($col = count($this->cells[$this->cursorRow]); $col < $this->cursorCol; ++$col) {
+        for ($col = \count($this->cells[$this->cursorRow]); $col < $this->cursorCol; ++$col) {
             $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
         }
 
@@ -460,13 +460,13 @@ final class ScreenBuffer
      */
     private function parseEscapeSequence(string $data, int $start): int
     {
-        $len = strlen($data);
+        $len = \strlen($data);
         if ($start + 1 >= $len) {
             return 1;
         }
 
         $next = $data[$start + 1];
-        $nextOrd = ord($next);
+        $nextOrd = \ord($next);
 
         // CSI sequence: ESC [
         if ('[' === $next) {
@@ -482,10 +482,10 @@ final class ScreenBuffer
         // nF announced sequences: ESC + intermediate bytes (0x20-0x2F)+ + final byte (0x30-0x7E)
         if ($nextOrd >= 0x20 && $nextOrd <= 0x2F) {
             $j = $start + 2;
-            while ($j < $len && ord($data[$j]) >= 0x20 && ord($data[$j]) <= 0x2F) {
+            while ($j < $len && \ord($data[$j]) >= 0x20 && \ord($data[$j]) <= 0x2F) {
                 ++$j;
             }
-            if ($j < $len && ord($data[$j]) >= 0x30 && ord($data[$j]) <= 0x7E) {
+            if ($j < $len && \ord($data[$j]) >= 0x30 && \ord($data[$j]) <= 0x7E) {
                 return $j + 1 - $start;
             }
 
@@ -507,7 +507,7 @@ final class ScreenBuffer
      */
     private function parseStringSequence(string $data, int $start): int
     {
-        $len = strlen($data);
+        $len = \strlen($data);
         $i = $start + 2; // Skip ESC + introducer byte
 
         // Find terminator: ST (ESC \) or BEL (\x07)
@@ -532,18 +532,18 @@ final class ScreenBuffer
      */
     private function parseCsiSequence(string $data, int $start): int
     {
-        $len = strlen($data);
+        $len = \strlen($data);
         $i = $start + 2; // Skip ESC [
 
         // Collect parameter bytes (0x30-0x3F)
         $params = '';
-        while ($i < $len && ord($data[$i]) >= 0x30 && ord($data[$i]) <= 0x3F) {
+        while ($i < $len && \ord($data[$i]) >= 0x30 && \ord($data[$i]) <= 0x3F) {
             $params .= $data[$i];
             ++$i;
         }
 
         // Collect intermediate bytes (0x20-0x2F)
-        while ($i < $len && ord($data[$i]) >= 0x20 && ord($data[$i]) <= 0x2F) {
+        while ($i < $len && \ord($data[$i]) >= 0x20 && \ord($data[$i]) <= 0x2F) {
             ++$i;
         }
 

--- a/src/Symfony/Component/Tui/Terminal/TeeTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/TeeTerminal.php
@@ -44,9 +44,9 @@ final class TeeTerminal implements TerminalInterface
         $this->primary->start($onInput, $onResize, $onKittyProtocolActivated);
 
         // Start secondary with no-op callbacks (they just record)
-        $noopInput = function (string $data): void {};
-        $noopResize = function (): void {};
-        $noopKitty = function (): void {};
+        $noopInput = static function (string $data): void {};
+        $noopResize = static function (): void {};
+        $noopKitty = static function (): void {};
 
         $this->secondary->start($noopInput, $noopResize, $noopKitty);
     }

--- a/src/Symfony/Component/Tui/Terminal/Terminal.php
+++ b/src/Symfony/Component/Tui/Terminal/Terminal.php
@@ -98,6 +98,7 @@ final class Terminal implements TerminalInterface
             $data = fread(\STDIN, 4096);
             if (false !== $data && '' !== $data && null !== $this->stdinBuffer) {
                 $this->stdinBuffer->process($data);
+                $this->stdinBuffer?->flush();
             }
         });
     }

--- a/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
@@ -53,7 +53,7 @@ final class VirtualTerminal implements TerminalInterface
         $this->stdinBuffer->onData($onInput);
 
         // Re-wrap paste content with bracketed paste markers (matches real Terminal behavior)
-        $this->stdinBuffer->onPaste(function (string $content) use ($onInput): void {
+        $this->stdinBuffer->onPaste(static function (string $content) use ($onInput): void {
             $onInput("\x1b[200~".$content."\x1b[201~");
         });
     }

--- a/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
@@ -178,6 +178,7 @@ final class VirtualTerminal implements TerminalInterface
     {
         if (null !== $this->stdinBuffer) {
             $this->stdinBuffer->process($data);
+            $this->stdinBuffer?->flush();
         }
     }
 

--- a/src/Symfony/Component/Tui/Tests/Focus/FocusManagerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Focus/FocusManagerTest.php
@@ -69,7 +69,7 @@ class FocusManagerTest extends TestCase
         $focusManager->add($first)->add($second);
 
         $received = null;
-        $tui->on(FocusEvent::class, function (FocusEvent $event) use (&$received): void {
+        $tui->on(FocusEvent::class, static function (FocusEvent $event) use (&$received): void {
             $received = $event;
         });
 

--- a/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
@@ -26,7 +26,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = bin2hex($data);
         });
 
@@ -145,7 +145,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = bin2hex($data);
         });
 
@@ -185,11 +185,11 @@ class StdinBufferTest extends TestCase
         $sequences = [];
         $pastedContent = null;
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = $data;
         });
 
-        $buffer->onPaste(function (string $content) use (&$pastedContent) {
+        $buffer->onPaste(static function (string $content) use (&$pastedContent) {
             $pastedContent = $content;
         });
 
@@ -204,7 +204,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = bin2hex($data);
         });
 
@@ -222,7 +222,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = bin2hex($data);
         });
 
@@ -243,7 +243,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = bin2hex($data);
         });
 
@@ -260,7 +260,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = $data;
         });
 
@@ -275,7 +275,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = $data;
         });
 
@@ -296,7 +296,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = bin2hex($data);
         });
 
@@ -325,7 +325,7 @@ class StdinBufferTest extends TestCase
         $pasteCount = 0;
         $pastedContent = null;
 
-        $buffer->onPaste(function (string $content) use (&$pastedContent, &$pasteCount) {
+        $buffer->onPaste(static function (string $content) use (&$pastedContent, &$pasteCount) {
             $pastedContent = $content;
             ++$pasteCount;
         });
@@ -350,10 +350,10 @@ class StdinBufferTest extends TestCase
         $sequences = [];
         $pastedContent = null;
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = $data;
         });
-        $buffer->onPaste(function (string $content) use (&$pastedContent) {
+        $buffer->onPaste(static function (string $content) use (&$pastedContent) {
             $pastedContent = $content;
         });
 
@@ -369,7 +369,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = $data;
         });
 
@@ -384,7 +384,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = $data;
         });
 
@@ -404,7 +404,7 @@ class StdinBufferTest extends TestCase
         $buffer = new StdinBuffer();
         $sequences = [];
 
-        $buffer->onData(function (string $data) use (&$sequences) {
+        $buffer->onData(static function (string $data) use (&$sequences) {
             $sequences[] = bin2hex($data);
         });
 

--- a/src/Symfony/Component/Tui/Tests/Loop/TickSchedulerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Loop/TickSchedulerTest.php
@@ -31,7 +31,7 @@ class TickSchedulerTest extends TestCase
         $calls = 0;
         $start = microtime(true);
 
-        $scheduler->schedule(function () use (&$calls): void {
+        $scheduler->schedule(static function () use (&$calls): void {
             ++$calls;
         }, 0.5);
 
@@ -54,7 +54,7 @@ class TickSchedulerTest extends TestCase
         $calls = 0;
         $start = microtime(true);
 
-        $id = $scheduler->schedule(function () use (&$calls): void {
+        $id = $scheduler->schedule(static function () use (&$calls): void {
             ++$calls;
         }, 0.01);
 

--- a/src/Symfony/Component/Tui/Tests/Render/CellBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/CellBufferTest.php
@@ -142,7 +142,7 @@ class CellBufferTest extends TestCase
         ], 1, 5);
 
         $lines = $buf->toLines();
-        $plain = array_map(fn ($l) => preg_replace('/\x1b\[[0-9;]*m/', '', $l), $lines);
+        $plain = array_map(static fn ($l) => preg_replace('/\x1b\[[0-9;]*m/', '', $l), $lines);
 
         $this->assertSame('Background content  ', $plain[0]);
         $this->assertSame('Line OVERLAYse      ', $plain[1]); // Overlay overwrites cols 5-11
@@ -273,7 +273,7 @@ class CellBufferTest extends TestCase
         $buf->writeAnsiLines(['Hello', 'World', '!']);
 
         $lines = $buf->toLines();
-        $plain = array_map(fn ($l) => preg_replace('/\x1b\[[0-9;]*m/', '', $l), $lines);
+        $plain = array_map(static fn ($l) => preg_replace('/\x1b\[[0-9;]*m/', '', $l), $lines);
 
         $this->assertSame('Hello     ', $plain[0]);
         $this->assertSame('World     ', $plain[1]);

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -248,7 +248,7 @@ class RendererTest extends TestCase
         // Only 2 visible children should produce lines
         $this->assertCount(2, $result);
 
-        $visible = implode("\n", array_map(fn (string $line) => AnsiUtils::stripAnsiCodes($line), $result));
+        $visible = implode("\n", array_map(static fn (string $line) => AnsiUtils::stripAnsiCodes($line), $result));
         $this->assertStringContainsString('Visible', $visible);
         $this->assertStringContainsString('Also visible', $visible);
         $this->assertStringNotContainsString('Hidden', $visible);

--- a/src/Symfony/Component/Tui/Tests/StateDiff.php
+++ b/src/Symfony/Component/Tui/Tests/StateDiff.php
@@ -50,7 +50,7 @@ final class StateDiff
 
         return [
             'identical' => false,
-            'summary' => sprintf(
+            'summary' => \sprintf(
                 '%d added, %d removed, %d changed, %d unchanged',
                 $stats['added'],
                 $stats['removed'],
@@ -72,7 +72,7 @@ final class StateDiff
     {
         $expectedLines = explode("\n", $expected);
         $actualLines = explode("\n", $actual);
-        $maxLines = max(count($expectedLines), count($actualLines));
+        $maxLines = max(\count($expectedLines), \count($actualLines));
         $colWidth = (int) (($width - 3) / 2);
 
         $output = [];
@@ -107,8 +107,8 @@ final class StateDiff
      */
     public static function generateHtmlReport(array $failures, array $successes = [], int $totalSteps = 0, int $passedSteps = 0, string $title = 'TUI Regression Report'): string
     {
-        $failureCount = count($failures);
-        $successCount = count($successes);
+        $failureCount = \count($failures);
+        $successCount = \count($successes);
         $hasFailures = $failureCount > 0;
 
         $titleColor = $hasFailures ? '#d32f2f' : '#2e7d32';
@@ -116,68 +116,68 @@ final class StateDiff
         $summaryBg = $hasFailures ? '#ffebee' : '#e8f5e9';
 
         $html = <<<'HTML'
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>%TITLE%</title>
-    <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 20px; background: #f5f5f5; }
-        h1 { color: %TITLE_COLOR%; }
-        h2.section-title { color: #333; margin-top: 30px; padding-bottom: 10px; border-bottom: 2px solid #ddd; }
-        .example { background: white; border: 1px solid #ddd; border-radius: 8px; margin: 20px 0; padding: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-        .example.failed { border-left: 4px solid #d32f2f; }
-        .example.passed { border-left: 4px solid #2e7d32; }
-        .example h3 { margin-top: 0; color: #333; border-bottom: 1px solid #eee; padding-bottom: 10px; display: flex; align-items: center; gap: 10px; }
-        .example h3 .badge { padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: bold; }
-        .example h3 .badge.failed { background: #ffebee; color: #c62828; }
-        .example h3 .badge.passed { background: #e8f5e9; color: #2e7d32; }
-        .diff { font-family: 'Monaco', 'Menlo', 'Courier New', monospace; font-size: 12px; overflow-x: auto; }
-        .diff-line { white-space: pre; padding: 2px 8px; }
-        .diff-removed { background: #ffebee; color: #c62828; }
-        .diff-added { background: #e8f5e9; color: #2e7d32; }
-        .diff-unchanged { color: #666; }
-        .diff-header { background: #f5f5f5; color: #666; font-weight: bold; }
-        .stats { background: #fff3e0; padding: 10px; border-radius: 4px; margin-bottom: 15px; }
-        .summary { background: %SUMMARY_BG%; padding: 15px; border-radius: 8px; margin-bottom: 20px; }
-        pre { margin: 0; background: #263238; color: #aed581; padding: 15px; border-radius: 4px; overflow-x: auto; }
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <title>%TITLE%</title>
+                <style>
+                    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 20px; background: #f5f5f5; }
+                    h1 { color: %TITLE_COLOR%; }
+                    h2.section-title { color: #333; margin-top: 30px; padding-bottom: 10px; border-bottom: 2px solid #ddd; }
+                    .example { background: white; border: 1px solid #ddd; border-radius: 8px; margin: 20px 0; padding: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+                    .example.failed { border-left: 4px solid #d32f2f; }
+                    .example.passed { border-left: 4px solid #2e7d32; }
+                    .example h3 { margin-top: 0; color: #333; border-bottom: 1px solid #eee; padding-bottom: 10px; display: flex; align-items: center; gap: 10px; }
+                    .example h3 .badge { padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: bold; }
+                    .example h3 .badge.failed { background: #ffebee; color: #c62828; }
+                    .example h3 .badge.passed { background: #e8f5e9; color: #2e7d32; }
+                    .diff { font-family: 'Monaco', 'Menlo', 'Courier New', monospace; font-size: 12px; overflow-x: auto; }
+                    .diff-line { white-space: pre; padding: 2px 8px; }
+                    .diff-removed { background: #ffebee; color: #c62828; }
+                    .diff-added { background: #e8f5e9; color: #2e7d32; }
+                    .diff-unchanged { color: #666; }
+                    .diff-header { background: #f5f5f5; color: #666; font-weight: bold; }
+                    .stats { background: #fff3e0; padding: 10px; border-radius: 4px; margin-bottom: 15px; }
+                    .summary { background: %SUMMARY_BG%; padding: 15px; border-radius: 8px; margin-bottom: 20px; }
+                    pre { margin: 0; background: #263238; color: #aed581; padding: 15px; border-radius: 4px; overflow-x: auto; }
 
-        /* Tab styles */
-        .steps-tabs { margin-bottom: 20px; }
-        .steps-tabs h4 { margin: 0 0 15px 0; color: #333; font-size: 14px; }
-        .tab-bar { display: flex; flex-wrap: wrap; gap: 4px; border-bottom: 2px solid #e0e0e0; padding-bottom: 0; margin-bottom: 0; }
-        .tab-btn { padding: 8px 12px; border: 1px solid #e0e0e0; border-bottom: none; border-radius: 6px 6px 0 0; background: #fafafa; cursor: pointer; font-size: 12px; display: flex; flex-direction: column; align-items: center; gap: 4px; margin-bottom: -2px; transition: all 0.15s ease; min-width: 60px; }
-        .tab-btn:hover { background: #f0f0f0; }
-        .tab-btn.active { background: white; border-color: #e0e0e0; border-bottom: 2px solid white; font-weight: 500; }
-        .tab-btn.tab-failed { border-color: #ef5350; background: #ffebee; }
-        .tab-btn.tab-failed.active { background: white; border-bottom-color: white; }
-        .tab-header { display: flex; align-items: center; gap: 6px; }
-        .tab-number { background: #1976d2; color: white; width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: bold; }
-        .tab-btn.tab-failed .tab-number { background: #d32f2f; }
-        .tab-action { color: #333; font-size: 11px; }
-        .tab-input { font-family: 'Monaco', 'Menlo', 'Courier New', monospace; background: #e3f2fd; color: #1565c0; padding: 2px 6px; border-radius: 3px; font-size: 10px; }
+                    /* Tab styles */
+                    .steps-tabs { margin-bottom: 20px; }
+                    .steps-tabs h4 { margin: 0 0 15px 0; color: #333; font-size: 14px; }
+                    .tab-bar { display: flex; flex-wrap: wrap; gap: 4px; border-bottom: 2px solid #e0e0e0; padding-bottom: 0; margin-bottom: 0; }
+                    .tab-btn { padding: 8px 12px; border: 1px solid #e0e0e0; border-bottom: none; border-radius: 6px 6px 0 0; background: #fafafa; cursor: pointer; font-size: 12px; display: flex; flex-direction: column; align-items: center; gap: 4px; margin-bottom: -2px; transition: all 0.15s ease; min-width: 60px; }
+                    .tab-btn:hover { background: #f0f0f0; }
+                    .tab-btn.active { background: white; border-color: #e0e0e0; border-bottom: 2px solid white; font-weight: 500; }
+                    .tab-btn.tab-failed { border-color: #ef5350; background: #ffebee; }
+                    .tab-btn.tab-failed.active { background: white; border-bottom-color: white; }
+                    .tab-header { display: flex; align-items: center; gap: 6px; }
+                    .tab-number { background: #1976d2; color: white; width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: bold; }
+                    .tab-btn.tab-failed .tab-number { background: #d32f2f; }
+                    .tab-action { color: #333; font-size: 11px; }
+                    .tab-input { font-family: 'Monaco', 'Menlo', 'Courier New', monospace; background: #e3f2fd; color: #1565c0; padding: 2px 6px; border-radius: 3px; font-size: 10px; }
 
-        .tab-content { display: none; border: 1px solid #e0e0e0; border-top: none; border-radius: 0 0 6px 6px; background: white; padding: 20px; }
-        .tab-content.active { display: block; }
+                    .tab-content { display: none; border: 1px solid #e0e0e0; border-top: none; border-radius: 0 0 6px 6px; background: white; padding: 20px; }
+                    .tab-content.active { display: block; }
 
-        .terminal-output { background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 4px; font-family: 'Monaco', 'Menlo', 'Courier New', monospace; font-size: 11px; white-space: pre; overflow: auto; line-height: 1.2; height: 400px; }
-        .output-label { margin: 0 0 8px 0; font-size: 13px; color: #666; }
-        .output-label.expected { color: #2e7d32; }
-        .output-label.actual { color: #d32f2f; }
+                    .terminal-output { background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 4px; font-family: 'Monaco', 'Menlo', 'Courier New', monospace; font-size: 11px; white-space: pre; overflow: auto; line-height: 1.2; height: 400px; }
+                    .output-label { margin: 0 0 8px 0; font-size: 13px; color: #666; }
+                    .output-label.expected { color: #2e7d32; }
+                    .output-label.actual { color: #d32f2f; }
 
-        .comparison { display: grid: grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 15px; }
-        .comparison-panel { }
-        .diff-section { padding-top: 15px; border-top: 1px solid #e0e0e0; }
-        .diff-section h4 { margin: 0 0 10px 0; font-size: 13px; color: #666; }
-    </style>
-</head>
-<body>
-    <h1>%TITLE_ICON% %TITLE%</h1>
-    <div class="summary">
-        <strong>Results:</strong> %PASSED_STEPS%/%TOTAL_STEPS% steps passed
-        (%SUCCESS_COUNT% examples passed, %FAILURE_COUNT% failed)
-    </div>
-HTML;
+                    .comparison { display: grid: grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 15px; }
+                    .comparison-panel { }
+                    .diff-section { padding-top: 15px; border-top: 1px solid #e0e0e0; }
+                    .diff-section h4 { margin: 0 0 10px 0; font-size: 13px; color: #666; }
+                </style>
+            </head>
+            <body>
+                <h1>%TITLE_ICON% %TITLE%</h1>
+                <div class="summary">
+                    <strong>Results:</strong> %PASSED_STEPS%/%TOTAL_STEPS% steps passed
+                    (%SUCCESS_COUNT% examples passed, %FAILURE_COUNT% failed)
+                </div>
+            HTML;
         $html = str_replace(
             ['%TITLE%', '%TITLE_COLOR%', '%TITLE_ICON%', '%SUMMARY_BG%', '%PASSED_STEPS%', '%TOTAL_STEPS%', '%SUCCESS_COUNT%', '%FAILURE_COUNT%'],
             [$title, $titleColor, $titleIcon, $summaryBg, (string) $passedSteps, (string) $totalSteps, (string) $successCount, (string) $failureCount],
@@ -186,7 +186,7 @@ HTML;
 
         // Failed examples section
         if ([] !== $failures) {
-            $html .= '<h2 class="section-title">❌ Failed Examples ('.count($failures).')</h2>';
+            $html .= '<h2 class="section-title">❌ Failed Examples ('.\count($failures).')</h2>';
 
             $failureIndex = 0;
             foreach ($failures as $name => $data) {
@@ -203,7 +203,7 @@ HTML;
 
                     // Tab bar
                     $html .= '<div class="tab-bar">';
-                    $stepCount = count($data['all_steps']);
+                    $stepCount = \count($data['all_steps']);
                     foreach ($data['all_steps'] as $index => $step) {
                         $isFailedStep = $index === $stepCount - 1;
                         $tabClass = 'tab-btn'.($isFailedStep ? ' tab-failed' : '').(0 === $index ? ' active' : '');
@@ -317,7 +317,7 @@ HTML;
 
         // Passed examples section
         if ([] !== $successes) {
-            $html .= '<h2 class="section-title">✅ Passed Examples ('.count($successes).')</h2>';
+            $html .= '<h2 class="section-title">✅ Passed Examples ('.\count($successes).')</h2>';
 
             $successIndex = 0;
             foreach ($successes as $name => $data) {
@@ -325,7 +325,7 @@ HTML;
                 $steps = $data['all_steps'];
 
                 $html .= '<div class="example passed">';
-                $html .= '<h3><span class="badge passed">PASSED</span> '.htmlspecialchars($data['example']).'.php <small style="color: #666; font-weight: normal;">('.count($steps).' steps)</small></h3>';
+                $html .= '<h3><span class="badge passed">PASSED</span> '.htmlspecialchars($data['example']).'.php <small style="color: #666; font-weight: normal;">('.\count($steps).' steps)</small></h3>';
 
                 // Show all steps as tabs
                 $html .= '<div class="steps-tabs">';
@@ -375,23 +375,23 @@ HTML;
 
         // Add JavaScript for tab switching
         $html .= <<<'HTML'
-<script>
-function showTab(prefix, index) {
-    // Hide all tab contents for this failure
-    document.querySelectorAll('[id^="' + prefix + '_step"][id$="_content"]').forEach(el => {
-        el.classList.remove('active');
-    });
-    // Deactivate all tab buttons for this failure
-    document.querySelectorAll('[id^="' + prefix + '_step"][id$="_btn"]').forEach(el => {
-        el.classList.remove('active');
-    });
-    // Show selected tab content and activate button
-    document.getElementById(prefix + '_step' + index + '_content').classList.add('active');
-    document.getElementById(prefix + '_step' + index + '_btn').classList.add('active');
-}
-</script>
-</body></html>
-HTML;
+            <script>
+            function showTab(prefix, index) {
+                // Hide all tab contents for this failure
+                document.querySelectorAll('[id^="' + prefix + '_step"][id$="_content"]').forEach(el => {
+                    el.classList.remove('active');
+                });
+                // Deactivate all tab buttons for this failure
+                document.querySelectorAll('[id^="' + prefix + '_step"][id$="_btn"]').forEach(el => {
+                    el.classList.remove('active');
+                });
+                // Show selected tab content and activate button
+                document.getElementById(prefix + '_step' + index + '_content').classList.add('active');
+                document.getElementById(prefix + '_step' + index + '_btn').classList.add('active');
+            }
+            </script>
+            </body></html>
+            HTML;
 
         return $html;
     }
@@ -406,8 +406,8 @@ HTML;
      */
     private static function computeDiff(array $expected, array $actual): array
     {
-        $m = count($expected);
-        $n = count($actual);
+        $m = \count($expected);
+        $n = \count($actual);
 
         // Build LCS table
         $lcs = [];
@@ -458,7 +458,7 @@ HTML;
 
         // Detect "changed" lines (adjacent removed + added)
         $result = [];
-        $diffCount = count($diff);
+        $diffCount = \count($diff);
 
         for ($k = 0; $k < $diffCount; ++$k) {
             $current = $diff[$k];
@@ -512,7 +512,7 @@ HTML;
         $lines = [];
         $lines[] = '--- expected';
         $lines[] = '+++ actual';
-        $lines[] = sprintf('@@ -%d,%d +%d,%d @@', 1, count($expected), 1, count($actual));
+        $lines[] = \sprintf('@@ -%d,%d +%d,%d @@', 1, \count($expected), 1, \count($actual));
 
         foreach ($diff as $entry) {
             switch ($entry['type']) {

--- a/src/Symfony/Component/Tui/Tests/Terminal/VirtualTerminalTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/VirtualTerminalTest.php
@@ -23,9 +23,9 @@ class VirtualTerminalTest extends TestCase
         $received = [];
 
         $terminal->start(
-            function (string $data) use (&$received) { $received[] = $data; },
-            function () {},
-            function () {},
+            static function (string $data) use (&$received) { $received[] = $data; },
+            static function () {},
+            static function () {},
         );
 
         $terminal->simulateInput('abc');
@@ -41,9 +41,9 @@ class VirtualTerminalTest extends TestCase
         $received = [];
 
         $terminal->start(
-            function (string $data) use (&$received) { $received[] = $data; },
-            function () {},
-            function () {},
+            static function (string $data) use (&$received) { $received[] = $data; },
+            static function () {},
+            static function () {},
         );
 
         $terminal->simulateInput("\x1b[200~Hello World\x1b[201~");
@@ -59,9 +59,9 @@ class VirtualTerminalTest extends TestCase
         $received = [];
 
         $terminal->start(
-            function (string $data) use (&$received) { $received[] = $data; },
-            function () {},
-            function () {},
+            static function (string $data) use (&$received) { $received[] = $data; },
+            static function () {},
+            static function () {},
         );
 
         $terminal->simulateInput("a\x1b[200~pasted\x1b[201~b");
@@ -112,9 +112,9 @@ class VirtualTerminalTest extends TestCase
         $received = [];
 
         $terminal->start(
-            function (string $data) use (&$received) { $received[] = $data; },
-            function () {},
-            function () {},
+            static function (string $data) use (&$received) { $received[] = $data; },
+            static function () {},
+            static function () {},
         );
 
         $terminal->simulateInput("\x1b[200~line1\nline2\nline3\x1b[201~");

--- a/src/Symfony/Component/Tui/Tests/TuiTest.php
+++ b/src/Symfony/Component/Tui/Tests/TuiTest.php
@@ -161,7 +161,7 @@ class TuiTest extends TestCase
         $ticks = 0;
 
         $tui->add($text);
-        $tui->onTick(function () use ($text, &$ticks): void {
+        $tui->onTick(static function () use ($text, &$ticks): void {
             if (0 === $ticks) {
                 $text->setText('1');
             }
@@ -187,7 +187,7 @@ class TuiTest extends TestCase
         $tui = new Tui(terminal: $terminal);
         $deltas = [];
 
-        $tui->onTick(function (TickEvent $event) use (&$deltas): void {
+        $tui->onTick(static function (TickEvent $event) use (&$deltas): void {
             $deltas[] = $event->getDeltaTime();
         });
 
@@ -289,7 +289,7 @@ class TuiTest extends TestCase
 
         $output = $terminal->getOutput();
         $lines = explode("\r\n", $output);
-        $stripped = array_map(fn (string $l) => AnsiUtils::stripAnsiCodes($l), $lines);
+        $stripped = array_map(static fn (string $l) => AnsiUtils::stripAnsiCodes($l), $lines);
 
         // Content should start at the first line, not be pushed to the bottom
         $headerLineIndex = null;
@@ -434,7 +434,7 @@ class TuiTest extends TestCase
         $tui->quitOn('ctrl+c');
 
         $onInputCalled = false;
-        $tui->onInput(function () use (&$onInputCalled): bool {
+        $tui->onInput(static function () use (&$onInputCalled): bool {
             $onInputCalled = true;
 
             return true;

--- a/src/Symfony/Component/Tui/Tests/TuiTest.php
+++ b/src/Symfony/Component/Tui/Tests/TuiTest.php
@@ -412,6 +412,34 @@ class TuiTest extends TestCase
         $this->assertSame('', $input->getValue());
     }
 
+    public function testQuitOnEscapeStopsTuiWhenEscapeIsSimulated()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $tui->quitOn(Key::ESCAPE);
+
+        $tui->start();
+        $this->assertTrue($tui->isRunning());
+
+        $terminal->simulateInput("\x1b"); // raw Esc byte
+
+        $this->assertFalse($tui->isRunning());
+    }
+
+    public function testQuitOnMultiByteKeyStopsTui()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $tui->quitOn(Key::UP);
+
+        $tui->start();
+        $this->assertTrue($tui->isRunning());
+
+        $terminal->simulateInput("\x1b[A"); // raw Arrow Up sequence
+
+        $this->assertFalse($tui->isRunning());
+    }
+
     public function testQuitOnDoesNotConsumeNonMatchingKeys()
     {
         $terminal = new VirtualTerminal(40, 10);

--- a/src/Symfony/Component/Tui/Tests/Widget/CancellableLoaderWidgetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/CancellableLoaderWidgetTest.php
@@ -41,7 +41,7 @@ class CancellableLoaderWidgetTest extends TestCase
         [$loader, $tui] = $this->createLoaderWithTui();
 
         $cancelCalled = false;
-        $tui->on(CancelEvent::class, function () use (&$cancelCalled): void {
+        $tui->on(CancelEvent::class, static function () use (&$cancelCalled): void {
             $cancelCalled = true;
         });
 
@@ -102,11 +102,11 @@ class CancellableLoaderWidgetTest extends TestCase
         $firstCalled = false;
         $secondCalled = false;
 
-        $tui->on(CancelEvent::class, function () use (&$firstCalled): void {
+        $tui->on(CancelEvent::class, static function () use (&$firstCalled): void {
             $firstCalled = true;
         });
 
-        $tui->on(CancelEvent::class, function () use (&$secondCalled): void {
+        $tui->on(CancelEvent::class, static function () use (&$secondCalled): void {
             $secondCalled = true;
         });
 
@@ -121,7 +121,7 @@ class CancellableLoaderWidgetTest extends TestCase
         [$loader, $tui] = $this->createLoaderWithTui();
         $callCount = 0;
 
-        $tui->on(CancelEvent::class, function () use (&$callCount): void {
+        $tui->on(CancelEvent::class, static function () use (&$callCount): void {
             ++$callCount;
         });
 
@@ -137,7 +137,7 @@ class CancellableLoaderWidgetTest extends TestCase
         [$loader, $tui] = $this->createLoaderWithTui();
         $callCount = 0;
 
-        $loader->onCancel(function () use (&$callCount): void {
+        $loader->onCancel(static function () use (&$callCount): void {
             ++$callCount;
         });
 

--- a/src/Symfony/Component/Tui/Tests/Widget/ContainerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ContainerTest.php
@@ -55,7 +55,7 @@ class ContainerTest extends TestCase
 
         $lines = $this->renderContainer($container);
 
-        $stripped = array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines);
+        $stripped = array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines);
         // Should have at least a top and bottom border line
         $this->assertGreaterThanOrEqual(2, \count($stripped));
         $this->assertStringContainsString('┌', $stripped[0]);
@@ -81,7 +81,7 @@ class ContainerTest extends TestCase
 
         $lines = $this->renderContainer($container);
 
-        $stripped = array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines);
+        $stripped = array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines);
         $this->assertStringContainsString('┌', $stripped[0]);
         $this->assertStringContainsString('└', $stripped[\count($stripped) - 1]);
     }
@@ -344,7 +344,7 @@ class ContainerTest extends TestCase
         $renderer = new Renderer($stylesheet);
         $lines = $renderer->render($root, 40, 24);
 
-        $text = implode("\n", array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
+        $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Visible', $text);
         $this->assertStringNotContainsString('Hidden', $text);
         $this->assertStringContainsString('Also Visible', $text);
@@ -416,13 +416,13 @@ class ContainerTest extends TestCase
 
         // Narrow: both visible
         $lines = $renderer->render($root, 60, 24);
-        $text = implode("\n", array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
+        $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Always', $text);
         $this->assertStringContainsString('Mobile Only', $text);
 
         // Wide: hint hidden
         $lines = $renderer->render($root, 120, 24);
-        $text = implode("\n", array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
+        $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Always', $text);
         $this->assertStringNotContainsString('Mobile Only', $text);
     }
@@ -442,7 +442,7 @@ class ContainerTest extends TestCase
         $renderer = new Renderer($stylesheet);
         $lines = $renderer->render($root, 40, 24);
 
-        $text = implode("\n", array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
+        $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Visible', $text);
     }
 
@@ -465,7 +465,7 @@ class ContainerTest extends TestCase
         $renderer = new Renderer();
         $lines = $renderer->render($root, 40, 24);
 
-        $text = implode("\n", array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
+        $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Before', $text);
         $this->assertStringNotContainsString('Child A', $text);
         $this->assertStringNotContainsString('Child B', $text);
@@ -499,7 +499,7 @@ class ContainerTest extends TestCase
         $lines = $this->renderContainer($container);
 
         // The text should be indented by 4 characters (left padding)
-        $content = implode("\n", array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
+        $content = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('    Padded', $content);
     }
 
@@ -555,7 +555,7 @@ class ContainerTest extends TestCase
 
         $lines = $this->renderContainer($container, 40);
 
-        $stripped = array_map(fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines);
+        $stripped = array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines);
 
         // First and "updated" text should both be present with a gap between them
         $firstIdx = null;

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
@@ -483,7 +483,7 @@ class EditorDocumentTest extends TestCase
     public function testLargePasteCreatesMarker()
     {
         $doc = new EditorDocument();
-        $content = implode("\n", array_map(fn ($i) => "line $i", range(1, 15)));
+        $content = implode("\n", array_map(static fn ($i) => "line $i", range(1, 15)));
         $doc->handlePaste($content);
 
         $markers = $doc->getPasteMarkers();
@@ -497,7 +497,7 @@ class EditorDocumentTest extends TestCase
     public function testSetTextClearsPasteMarkers()
     {
         $doc = new EditorDocument();
-        $content = implode("\n", array_map(fn ($i) => "line $i", range(1, 15)));
+        $content = implode("\n", array_map(static fn ($i) => "line $i", range(1, 15)));
         $doc->handlePaste($content);
         $this->assertNotSame([], $doc->getPasteMarkers());
 

--- a/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
@@ -96,7 +96,7 @@ class EditorTest extends TestCase
         [$editor, $tui] = $this->createEditorWithTui();
 
         $changedText = null;
-        $tui->on(ChangeEvent::class, function (ChangeEvent $e) use (&$changedText) {
+        $tui->on(ChangeEvent::class, static function (ChangeEvent $e) use (&$changedText) {
             $changedText = $e->getValue();
         });
 

--- a/src/Symfony/Component/Tui/Tests/Widget/Figlet/FigletFontTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Figlet/FigletFontTest.php
@@ -43,7 +43,7 @@ class FigletFontTest extends TestCase
         for ($code = 32; $code <= 126; ++$code) {
             $this->assertTrue(
                 $font->hasCharacter($code),
-                \sprintf('Font "%s" is missing character %d (%s)', $name, $code, chr($code)),
+                \sprintf('Font "%s" is missing character %d (%s)', $name, $code, \chr($code)),
             );
         }
     }

--- a/src/Symfony/Component/Tui/Tests/Widget/Figlet/FontRegistryTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Figlet/FontRegistryTest.php
@@ -82,7 +82,7 @@ class FontRegistryTest extends TestCase
         $registry = new FontRegistry();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('big, small, slant, standard, mini');
+        $this->expectExceptionMessage('"big", "small", "slant", "standard", "mini"');
 
         $registry->get('unknown');
     }

--- a/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
@@ -114,7 +114,7 @@ class InputTest extends TestCase
         [$input, $tui] = $this->createInputWithTui();
 
         $submitted = null;
-        $tui->on(SubmitEvent::class, function (SubmitEvent $e) use (&$submitted) {
+        $tui->on(SubmitEvent::class, static function (SubmitEvent $e) use (&$submitted) {
             $submitted = $e->getValue();
         });
 
@@ -129,7 +129,7 @@ class InputTest extends TestCase
         [$input, $tui] = $this->createInputWithTui();
 
         $cancelled = false;
-        $tui->on(CancelEvent::class, function (CancelEvent $e) use (&$cancelled) {
+        $tui->on(CancelEvent::class, static function (CancelEvent $e) use (&$cancelled) {
             $cancelled = true;
         });
 
@@ -143,7 +143,7 @@ class InputTest extends TestCase
         $input = new InputWidget();
 
         $intercepted = false;
-        $input->onInput(function (string $data) use (&$intercepted): bool {
+        $input->onInput(static function (string $data) use (&$intercepted): bool {
             if ('x' === $data) {
                 $intercepted = true;
 
@@ -162,9 +162,7 @@ class InputTest extends TestCase
     {
         $input = new InputWidget();
 
-        $input->onInput(function (string $data): bool {
-            return 'x' === $data;
-        });
+        $input->onInput(static fn (string $data): bool => 'x' === $data);
 
         $input->handleInput('y');
         $this->assertSame('y', $input->getValue(), 'Non-consumed input should be typed');
@@ -253,7 +251,7 @@ class InputTest extends TestCase
         [$input, $tui] = $this->createInputWithTui();
 
         $changedValue = null;
-        $tui->on(ChangeEvent::class, function (ChangeEvent $e) use (&$changedValue) {
+        $tui->on(ChangeEvent::class, static function (ChangeEvent $e) use (&$changedValue) {
             $changedValue = $e->getValue();
         });
 

--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -71,7 +71,7 @@ class MarkdownTest extends TestCase
         $lines = $this->renderThroughRenderer($md, 40, 24);
 
         // Should have top + content + bottom = 3 lines
-        $this->assertSame(3, \count($lines));
+        $this->assertCount(3, $lines);
     }
 
     public function testAllLinesRespectWidth()

--- a/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
@@ -248,7 +248,7 @@ class ProgressBarTest extends TestCase
     {
         $bar = new ProgressBarWidget(100);
         $bar->setFormat('%custom%');
-        $bar->setPlaceholderFormatter('custom', fn (ProgressBarWidget $b) => 'step-'.$b->getProgress());
+        $bar->setPlaceholderFormatter('custom', static fn (ProgressBarWidget $b) => 'step-'.$b->getProgress());
 
         $bar->setProgress(7);
 
@@ -260,7 +260,7 @@ class ProgressBarTest extends TestCase
 
     public function testDefaultPlaceholderFormatter()
     {
-        ProgressBarWidget::setDefaultPlaceholderFormatter('global_test', fn (ProgressBarWidget $b) => 'G'.$b->getProgress());
+        ProgressBarWidget::setDefaultPlaceholderFormatter('global_test', static fn (ProgressBarWidget $b) => 'G'.$b->getProgress());
 
         $bar = new ProgressBarWidget(100);
         $bar->setFormat('%global_test%');
@@ -274,11 +274,11 @@ class ProgressBarTest extends TestCase
 
     public function testInstanceFormatterOverridesDefault()
     {
-        ProgressBarWidget::setDefaultPlaceholderFormatter('override_test', fn (ProgressBarWidget $b) => 'DEFAULT');
+        ProgressBarWidget::setDefaultPlaceholderFormatter('override_test', static fn (ProgressBarWidget $b) => 'DEFAULT');
 
         $bar = new ProgressBarWidget(100);
         $bar->setFormat('%override_test%');
-        $bar->setPlaceholderFormatter('override_test', fn (ProgressBarWidget $b) => 'INSTANCE');
+        $bar->setPlaceholderFormatter('override_test', static fn (ProgressBarWidget $b) => 'INSTANCE');
 
         $lines = $bar->render(new RenderContext(80, 24));
         $content = $lines[0];

--- a/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
@@ -93,7 +93,7 @@ class SelectListTest extends TestCase
         [$list, $tui] = $this->createTestListWithTui();
 
         $selectedItem = null;
-        $tui->on(SelectEvent::class, function (SelectEvent $e) use (&$selectedItem) {
+        $tui->on(SelectEvent::class, static function (SelectEvent $e) use (&$selectedItem) {
             $selectedItem = $e->getItem();
         });
 
@@ -108,7 +108,7 @@ class SelectListTest extends TestCase
         [$list, $tui] = $this->createTestListWithTui();
 
         $cancelled = false;
-        $tui->on(CancelEvent::class, function (CancelEvent $e) use (&$cancelled) {
+        $tui->on(CancelEvent::class, static function (CancelEvent $e) use (&$cancelled) {
             $cancelled = true;
         });
 
@@ -176,7 +176,7 @@ class SelectListTest extends TestCase
         [$list, $tui] = $this->createTestListWithTui();
 
         $changedItem = null;
-        $tui->on(SelectionChangeEvent::class, function (SelectionChangeEvent $e) use (&$changedItem) {
+        $tui->on(SelectionChangeEvent::class, static function (SelectionChangeEvent $e) use (&$changedItem) {
             $changedItem = $e->getItem();
         });
 
@@ -193,7 +193,7 @@ class SelectListTest extends TestCase
         $list->setFilter('nonexistent');
 
         $selectionChanged = false;
-        $tui->on(SelectionChangeEvent::class, function () use (&$selectionChanged) {
+        $tui->on(SelectionChangeEvent::class, static function () use (&$selectionChanged) {
             $selectionChanged = true;
         });
 
@@ -221,7 +221,7 @@ class SelectListTest extends TestCase
         $list->setFilter('nonexistent');
 
         $cancelled = false;
-        $tui->on(CancelEvent::class, function () use (&$cancelled) {
+        $tui->on(CancelEvent::class, static function () use (&$cancelled) {
             $cancelled = true;
         });
 

--- a/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
@@ -67,7 +67,7 @@ class SettingsListTest extends TestCase
 
         $changedId = null;
         $changedValue = null;
-        $tui->on(SettingChangeEvent::class, function (SettingChangeEvent $e) use (&$changedId, &$changedValue) {
+        $tui->on(SettingChangeEvent::class, static function (SettingChangeEvent $e) use (&$changedId, &$changedValue) {
             $changedId = $e->getId();
             $changedValue = $e->getValue();
         });
@@ -84,7 +84,7 @@ class SettingsListTest extends TestCase
         [$widget, $tui] = $this->createWithTui();
 
         $cancelled = false;
-        $tui->on(CancelEvent::class, function (CancelEvent $e) use (&$cancelled) {
+        $tui->on(CancelEvent::class, static function (CancelEvent $e) use (&$cancelled) {
             $cancelled = true;
         });
 
@@ -116,7 +116,7 @@ class SettingsListTest extends TestCase
                 id: 'model',
                 label: 'Model',
                 currentValue: 'gpt-4',
-                submenu: function (string $currentValue, callable $onDone) use (&$submenuWidget) {
+                submenu: static function (string $currentValue, callable $onDone) use (&$submenuWidget) {
                     $list = new SelectListWidget([
                         ['value' => 'gpt-4', 'label' => 'GPT-4'],
                         ['value' => 'claude', 'label' => 'Claude'],
@@ -173,7 +173,7 @@ class SettingsListTest extends TestCase
                 id: 'model',
                 label: 'Model',
                 currentValue: 'gpt-4',
-                submenu: function (string $currentValue, callable $onDone) use (&$onDoneCallback) {
+                submenu: static function (string $currentValue, callable $onDone) use (&$onDoneCallback) {
                     $onDoneCallback = $onDone;
 
                     $list = new SelectListWidget([
@@ -206,7 +206,7 @@ class SettingsListTest extends TestCase
                 id: 'model',
                 label: 'Model',
                 currentValue: 'gpt-4',
-                submenu: function (string $currentValue, callable $onDone) {
+                submenu: static function (string $currentValue, callable $onDone) {
                     $list = new SelectListWidget([
                         ['value' => 'gpt-4', 'label' => 'GPT-4'],
                         ['value' => 'claude', 'label' => 'Claude'],
@@ -240,12 +240,10 @@ class SettingsListTest extends TestCase
                 id: 'model',
                 label: 'Model',
                 currentValue: 'gpt-4',
-                submenu: function (string $currentValue, callable $onDone) {
-                    return new SelectListWidget([
-                        ['value' => 'gpt-4', 'label' => 'GPT-4'],
-                        ['value' => 'claude', 'label' => 'Claude'],
-                    ], 5);
-                },
+                submenu: static fn (string $currentValue, callable $onDone) => new SelectListWidget([
+                    ['value' => 'gpt-4', 'label' => 'GPT-4'],
+                    ['value' => 'claude', 'label' => 'Claude'],
+                ], 5),
             ),
         ];
 

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -109,7 +109,7 @@ abstract class AbstractWidget
         return null;
     }
 
-    final public function getParent(): ?AbstractWidget
+    final public function getParent(): ?self
     {
         return $this->parent;
     }
@@ -158,7 +158,7 @@ abstract class AbstractWidget
     {
         $newClasses = array_values(array_filter(
             $this->styleClasses,
-            fn (string $c) => $c !== $class,
+            static fn (string $c) => $c !== $class,
         ));
 
         if ($newClasses !== $this->styleClasses) {
@@ -200,7 +200,7 @@ abstract class AbstractWidget
     /**
      * @internal
      */
-    final public function attach(?AbstractWidget $parent, WidgetContext $context): void
+    final public function attach(?self $parent, WidgetContext $context): void
     {
         $this->parent = $parent;
         $this->context = $context;
@@ -384,7 +384,7 @@ abstract class AbstractWidget
     /**
      * @internal
      */
-    final protected function setParent(?AbstractWidget $parent): void
+    final protected function setParent(?self $parent): void
     {
         $this->parent = $parent;
         $this->invalidate();

--- a/src/Symfony/Component/Tui/Widget/ContainerWidget.php
+++ b/src/Symfony/Component/Tui/Widget/ContainerWidget.php
@@ -163,6 +163,6 @@ class ContainerWidget extends AbstractWidget implements ContainerInterface, Vert
      */
     public function render(RenderContext $context): array
     {
-        throw new LogicException(\sprintf('%s rendering is handled by the Renderer via renderContainer(). This method should never be called directly.', static::class));
+        throw new LogicException(\sprintf('"%s" rendering is handled by the Renderer via "renderContainer()"; this method should never be called directly.', static::class));
     }
 }

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
@@ -182,10 +182,10 @@ final class EditorRenderer
                 $cursorCharIndex = \count($graphemes);
             }
 
-            $beforeCursor = implode('', array_slice($graphemes, 0, $cursorCharIndex));
+            $beforeCursor = implode('', \array_slice($graphemes, 0, $cursorCharIndex));
             if (isset($graphemes[$cursorCharIndex])) {
                 $atCursor = $graphemes[$cursorCharIndex];
-                $afterCursor = implode('', array_slice($graphemes, $cursorCharIndex + 1));
+                $afterCursor = implode('', \array_slice($graphemes, $cursorCharIndex + 1));
             }
         }
         if (false === $graphemes) {

--- a/src/Symfony/Component/Tui/Widget/Figlet/FontRegistry.php
+++ b/src/Symfony/Component/Tui/Widget/Figlet/FontRegistry.php
@@ -76,7 +76,7 @@ final class FontRegistry
         }
 
         if (!isset($this->paths[$name])) {
-            throw new InvalidArgumentException(\sprintf('Font "%s" is not registered. Available fonts: %s.', $name, implode(', ', array_keys($this->paths))));
+            throw new InvalidArgumentException(\sprintf('Font "%s" is not registered. Available fonts: "%s".', $name, implode('", "', array_keys($this->paths))));
         }
 
         return $this->fonts[$name] = FigletFont::load($this->paths[$name]);

--- a/src/Symfony/Component/Tui/Widget/LoaderWidget.php
+++ b/src/Symfony/Component/Tui/Widget/LoaderWidget.php
@@ -135,7 +135,7 @@ class LoaderWidget extends AbstractWidget
     public function setSpinner(string $name): self
     {
         if (!isset(self::$styles[$name])) {
-            throw new \InvalidArgumentException(\sprintf('Unknown loader style "%s". Available styles: %s.', $name, implode(', ', array_keys(self::$styles))));
+            throw new \InvalidArgumentException(\sprintf('Unknown loader style "%s". Available styles: "%s".', $name, implode('", "', array_keys(self::$styles))));
         }
 
         $this->frames = self::$styles[$name];

--- a/src/Symfony/Component/Tui/Widget/Markdown/DarkTerminalTheme.php
+++ b/src/Symfony/Component/Tui/Widget/Markdown/DarkTerminalTheme.php
@@ -58,7 +58,7 @@ final class DarkTerminalTheme implements TerminalTheme
         }
 
         // Use 24-bit RGB escape sequence
-        return sprintf("\x1b[38;2;%d;%d;%dm", $rgb[0], $rgb[1], $rgb[2]);
+        return \sprintf("\x1b[38;2;%d;%d;%dm", $rgb[0], $rgb[1], $rgb[2]);
     }
 
     public function after(TokenType $tokenType): string

--- a/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
+++ b/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
@@ -458,7 +458,7 @@ class MarkdownWidget extends AbstractWidget
         $lines = [];
 
         // Top border
-        $topBorderCells = array_map(fn (int $w) => str_repeat('─', $w), $columnWidths);
+        $topBorderCells = array_map(static fn (int $w) => str_repeat('─', $w), $columnWidths);
         $lines[] = '┌─'.implode('─┬─', $topBorderCells).'─┐';
 
         // Header row
@@ -482,7 +482,7 @@ class MarkdownWidget extends AbstractWidget
             }
 
             // Separator
-            $separatorCells = array_map(fn (int $w) => str_repeat('─', $w), $columnWidths);
+            $separatorCells = array_map(static fn (int $w) => str_repeat('─', $w), $columnWidths);
             $lines[] = '├─'.implode('─┼─', $separatorCells).'─┤';
         }
 
@@ -506,7 +506,7 @@ class MarkdownWidget extends AbstractWidget
         }
 
         // Bottom border
-        $bottomBorderCells = array_map(fn (int $w) => str_repeat('─', $w), $columnWidths);
+        $bottomBorderCells = array_map(static fn (int $w) => str_repeat('─', $w), $columnWidths);
         $lines[] = '└─'.implode('─┴─', $bottomBorderCells).'─┘';
 
         return $lines;

--- a/src/Symfony/Component/Tui/Widget/ScheduledTickTrait.php
+++ b/src/Symfony/Component/Tui/Widget/ScheduledTickTrait.php
@@ -32,7 +32,7 @@ trait ScheduledTickTrait
     protected function startScheduledTick(float $intervalSeconds): void
     {
         if ($intervalSeconds <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %s.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
         }
 
         if (null !== $this->scheduledTickId && null !== $this->scheduledTickInterval && abs($this->scheduledTickInterval - $intervalSeconds) < 0.000001) {

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -75,7 +75,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
 
         $filteredItems = array_values(array_filter(
             $this->items,
-            fn ($item) => str_starts_with(strtolower($item['value']), $filter),
+            static fn ($item) => str_starts_with(strtolower($item['value']), $filter),
         ));
 
         if ($filteredItems !== $this->filteredItems) {

--- a/src/Symfony/Component/Tui/Widget/SettingsListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SettingsListWidget.php
@@ -378,12 +378,12 @@ class SettingsListWidget extends AbstractWidget implements FocusableInterface, P
                 // Wire submenu events: when the inner widget dispatches
                 // SelectEvent or CancelEvent, route to the onDone callback
                 $dispatcher = $context->getEventDispatcher();
-                $selectListener = function (SelectEvent $e) use ($submenu, $onDone): void {
+                $selectListener = static function (SelectEvent $e) use ($submenu, $onDone): void {
                     if ($e->getTarget() === $submenu) {
                         $onDone($e->getValue());
                     }
                 };
-                $cancelListener = function (CancelEvent $e) use ($submenu, $onDone): void {
+                $cancelListener = static function (CancelEvent $e) use ($submenu, $onDone): void {
                     if ($e->getTarget() === $submenu) {
                         $onDone(null);
                     }


### PR DESCRIPTION
  | Q             | A
  | ------------- | ---
  | Branch?       | 8.1
  | Bug fix?      | yes
  | New feature?  | no
  | Deprecations? | no
  | Issues        | 
  | License       | MIT


Calling `quitOn()` with certain keys had no effect, as shown in this demo:


```php
$tui = new Tui();
$tui->add(new TextWidget('Hello TUI!'));
$tui->add(new TextWidget('Press Esc or Arrow Up to quit.'));
$tui->quitOn(Key::ESCAPE, Key::UP);
$tui->run();
```


Two bugs were found and fixed:

1. The Escape key sends the raw byte `\x1b` to the terminal. Because `\x1b` is also the first byte of all escape sequences (arrow keys, function keys, etc.), `StdinBuffer` holds it in its buffer waiting for more bytes before deciding what sequence it is. When Esc is pressed alone no further bytes arrive, so `handleInput()` is never called and the quit check never runs.
    OS terminals deliver complete escape sequences atomically in a single read, so a lone `\x1b` remaining in the buffer after processing a chunk of input can only mean the Escape key was pressed. Calling `flush()` immediately after each `process()` emits the pending `\x1b` and resolves the ambiguity correctly.

2. For multi-byte keys (e.g. arrow keys), the sequence is dispatched synchronously inside `process()`, which triggers `stop()`, which sets `$stdinBuffer` to null, before the `flush()` call that follows `process()` in the event loop callback. This caused a fatal error. Using the nullsafe operator (`?->flush()`) prevents the crash.

---

_Note: I'm not sure this is the right place for such a fix, let me know if I should address it directly in the [Symfony PR](https://github.com/symfony/symfony/pull/63778) instead (or what would be the appropriate way to submit a patch)._