### PR TITLE
[Tui] Add CollapsibleWidget for expandable content sections

### DIFF
--- a/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
+++ b/src/Symfony/Component/Tui/Style/DefaultStyleSheet.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Style;
 
 use Symfony\Component\Tui\Widget\CancellableLoaderWidget;
+use Symfony\Component\Tui\Widget\CollapsibleWidget;
 use Symfony\Component\Tui\Widget\EditorWidget;
 use Symfony\Component\Tui\Widget\InputWidget;
 use Symfony\Component\Tui\Widget\LoaderWidget;
@@ -50,6 +51,10 @@ final class DefaultStyleSheet
             // Layout aliases (used by <columns>/<column> tag aliases)
             '.columns' => new Style(direction: Direction::Horizontal, gap: 2),
             '.column' => new Style(),
+
+            // CollapsibleWidget
+            CollapsibleWidget::class.'::header' => new Style()->withBold(),
+            CollapsibleWidget::class.'::hint' => new Style()->withDim(),
 
             // CancellableLoaderWidget
             CancellableLoaderWidget::class.':focus' => new Style()->withBold(),

--- a/src/Symfony/Component/Tui/Tests/Widget/CollapsibleTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/CollapsibleTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Widget;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Render\Renderer;
+use Symfony\Component\Tui\Widget\CollapsibleWidget;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+use Symfony\Component\Tui\Widget\ToggleableInterface;
+
+class CollapsibleTest extends TestCase
+{
+    public function testImplementsToggleableInterface()
+    {
+        $widget = new CollapsibleWidget();
+        $this->assertInstanceOf(ToggleableInterface::class, $widget);
+    }
+
+    public function testCollapsedRenderShowsPreviewLines()
+    {
+        $content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7";
+        $widget = new CollapsibleWidget($content, 'Header');
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        // Header + 3 preview lines + hint = 5 lines
+        $this->assertCount(5, $lines);
+        $this->assertStringContainsString('Header', $lines[0]);
+        $this->assertStringContainsString('Line 1', $lines[1]);
+        $this->assertStringContainsString('Line 2', $lines[2]);
+        $this->assertStringContainsString('Line 3', $lines[3]);
+        $this->assertStringContainsString('+4 more lines', $lines[4]);
+    }
+
+    public function testExpandedRenderShowsAllLines()
+    {
+        $content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
+        $widget = new CollapsibleWidget($content, 'Header');
+        $widget->setExpanded(true);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        // Header + 5 content lines = 6 lines
+        $this->assertCount(6, $lines);
+        $this->assertStringContainsString('Header', $lines[0]);
+        $this->assertStringContainsString('Line 5', $lines[5]);
+    }
+
+    public function testToggleFlipsState()
+    {
+        $widget = new CollapsibleWidget();
+        $this->assertFalse($widget->isExpanded());
+
+        $widget->toggle();
+        $this->assertTrue($widget->isExpanded());
+
+        $widget->toggle();
+        $this->assertFalse($widget->isExpanded());
+    }
+
+    public function testSetExpandedIsIdempotent()
+    {
+        $widget = new CollapsibleWidget();
+
+        $widget->setExpanded(false);
+        $this->assertFalse($widget->isExpanded());
+
+        $widget->setExpanded(true);
+        $this->assertTrue($widget->isExpanded());
+
+        $widget->setExpanded(true);
+        $this->assertTrue($widget->isExpanded());
+    }
+
+    public function testHintShowsSingularWhenOneLine()
+    {
+        $content = "Line 1\nLine 2\nLine 3\nLine 4";
+        $widget = new CollapsibleWidget($content, previewLines: 3);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        $lastLine = $lines[\count($lines) - 1];
+        $this->assertStringContainsString('+1 more line', $lastLine);
+        $this->assertStringNotContainsString('lines', $lastLine);
+    }
+
+    public function testHintShowsPluralWhenMultipleLines()
+    {
+        $content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
+        $widget = new CollapsibleWidget($content, previewLines: 2);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        $lastLine = $lines[\count($lines) - 1];
+        $this->assertStringContainsString('+3 more lines', $lastLine);
+    }
+
+    public function testNoHintWhenContentFitsInPreview()
+    {
+        $content = "Line 1\nLine 2";
+        $widget = new CollapsibleWidget($content, previewLines: 3);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        // 2 content lines, no hint since they fit in preview
+        $this->assertCount(2, $lines);
+        foreach ($lines as $line) {
+            $this->assertStringNotContainsString('more line', $line);
+        }
+    }
+
+    public function testEmptyContentRendersEmpty()
+    {
+        $widget = new CollapsibleWidget();
+        $lines = $widget->render(new RenderContext(40, 24));
+
+        $this->assertSame([], $lines);
+    }
+
+    public function testHeaderOnlyRendersOneLine()
+    {
+        $widget = new CollapsibleWidget('', 'Just a header');
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        $this->assertCount(1, $lines);
+        $this->assertStringContainsString('Just a header', $lines[0]);
+    }
+
+    public function testLongLinesAreTruncated()
+    {
+        $longLine = str_repeat('A', 100);
+        $widget = new CollapsibleWidget($longLine);
+        $widget->setExpanded(true);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(40, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testAnsiContentPreserved()
+    {
+        $content = "\x1b[32mGreen text\x1b[0m\nNormal text";
+        $widget = new CollapsibleWidget($content);
+        $widget->setExpanded(true);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        $this->assertStringContainsString("\x1b[32m", $lines[0]);
+        $this->assertStringContainsString('Green text', $lines[0]);
+    }
+
+    public function testCustomPreviewLines()
+    {
+        $content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
+        $widget = new CollapsibleWidget($content, previewLines: 1);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        // 1 preview line + hint = 2 lines
+        $this->assertCount(2, $lines);
+        $this->assertStringContainsString('Line 1', $lines[0]);
+        $this->assertStringContainsString('+4 more lines', $lines[1]);
+    }
+
+    public function testSetContentInvalidates()
+    {
+        $widget = new CollapsibleWidget('Old content');
+        $widget->setExpanded(true);
+
+        $lines1 = $this->renderWidget($widget, 40, 24);
+
+        $widget->setContent('New content');
+        $lines2 = $this->renderWidget($widget, 40, 24);
+
+        $this->assertStringContainsString('Old content', $lines1[0]);
+        $this->assertStringContainsString('New content', $lines2[0]);
+    }
+
+    public function testToggleAllRecursive()
+    {
+        $root = new ContainerWidget();
+
+        $c1 = new CollapsibleWidget("Line 1\nLine 2\nLine 3\nLine 4\nLine 5");
+        $c2 = new CollapsibleWidget("Line 1\nLine 2\nLine 3\nLine 4");
+
+        $nested = new ContainerWidget();
+        $c3 = new CollapsibleWidget("Line 1\nLine 2\nLine 3\nLine 4");
+        $nested->add($c3);
+
+        $root->add($c1);
+        $root->add($c2);
+        $root->add($nested);
+
+        $this->assertFalse($c1->isExpanded());
+        $this->assertFalse($c2->isExpanded());
+        $this->assertFalse($c3->isExpanded());
+
+        CollapsibleWidget::toggleAll($root);
+
+        $this->assertTrue($c1->isExpanded());
+        $this->assertTrue($c2->isExpanded());
+        $this->assertTrue($c3->isExpanded());
+
+        CollapsibleWidget::toggleAll($root);
+
+        $this->assertFalse($c1->isExpanded());
+        $this->assertFalse($c2->isExpanded());
+        $this->assertFalse($c3->isExpanded());
+    }
+
+    public function testZeroPreviewLines()
+    {
+        $content = "Line 1\nLine 2\nLine 3";
+        $widget = new CollapsibleWidget($content, previewLines: 0);
+
+        $lines = $this->renderWidget($widget, 40, 24);
+
+        // 0 preview lines + hint = 1 line
+        $this->assertCount(1, $lines);
+        $this->assertStringContainsString('+3 more lines', $lines[0]);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function renderWidget(CollapsibleWidget $widget, int $columns, int $rows): array
+    {
+        $renderer = new Renderer();
+
+        return $renderer->renderWidget($widget, new RenderContext($columns, $rows));
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/CollapsibleWidget.php
+++ b/src/Symfony/Component/Tui/Widget/CollapsibleWidget.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Ansi\TextWrapper;
+use Symfony\Component\Tui\Render\RenderContext;
+
+/**
+ * Collapsible content widget that shows a preview when collapsed.
+ *
+ * When collapsed, renders a configurable number of preview lines followed
+ * by a hint showing how many lines are hidden. When expanded, renders
+ * all content lines.
+ *
+ * Style elements:
+ * - "header" — the header line
+ * - "hint"   — the "+N more lines" indicator when collapsed
+ *
+ * @experimental
+ */
+class CollapsibleWidget extends AbstractWidget implements ToggleableInterface
+{
+    private bool $expanded = false;
+
+    public function __construct(
+        private string $content = '',
+        private string $header = '',
+        private int $previewLines = 3,
+    ) {
+    }
+
+    public function setContent(string $content): static
+    {
+        if ($this->content !== $content) {
+            $this->content = $content;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function setHeader(string $header): static
+    {
+        if ($this->header !== $header) {
+            $this->header = $header;
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function getHeader(): string
+    {
+        return $this->header;
+    }
+
+    public function setPreviewLines(int $lines): static
+    {
+        if ($this->previewLines !== $lines) {
+            $this->previewLines = max(0, $lines);
+            $this->invalidate();
+        }
+
+        return $this;
+    }
+
+    public function getPreviewLines(): int
+    {
+        return $this->previewLines;
+    }
+
+    public function toggle(): void
+    {
+        $this->expanded = !$this->expanded;
+        $this->invalidate();
+    }
+
+    public function setExpanded(bool $expanded): void
+    {
+        if ($this->expanded !== $expanded) {
+            $this->expanded = $expanded;
+            $this->invalidate();
+        }
+    }
+
+    public function isExpanded(): bool
+    {
+        return $this->expanded;
+    }
+
+    public function render(RenderContext $context): array
+    {
+        $columns = $context->getColumns();
+
+        if ('' === $this->content && '' === $this->header) {
+            return [];
+        }
+
+        $result = [];
+
+        // Render header
+        if ('' !== $this->header) {
+            $headerText = $this->applyElement('header', $this->header);
+            $result[] = AnsiUtils::truncateToWidth($headerText, $columns, '');
+        }
+
+        // Normalize and split content into lines
+        $normalized = str_replace("\t", '   ', $this->content);
+        $contentLines = '' !== $normalized
+            ? TextWrapper::wrapTextWithAnsi($normalized, $columns)
+            : [];
+
+        if ($this->expanded || \count($contentLines) <= $this->previewLines) {
+            // Show all lines
+            foreach ($contentLines as $line) {
+                $result[] = AnsiUtils::truncateToWidth($line, $columns, '');
+            }
+        } else {
+            // Show preview lines
+            for ($i = 0; $i < $this->previewLines && $i < \count($contentLines); ++$i) {
+                $result[] = AnsiUtils::truncateToWidth($contentLines[$i], $columns, '');
+            }
+
+            // Show hint
+            $hiddenCount = \count($contentLines) - $this->previewLines;
+            $hintText = \sprintf('▸ +%d more line%s', $hiddenCount, $hiddenCount > 1 ? 's' : '');
+            $result[] = $this->applyElement('hint', $hintText);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Recursively toggle all ToggleableInterface widgets in a container tree.
+     */
+    public static function toggleAll(ContainerWidget $container): void
+    {
+        foreach ($container->all() as $child) {
+            if ($child instanceof ToggleableInterface) {
+                $child->toggle();
+            }
+            if ($child instanceof ContainerWidget) {
+                self::toggleAll($child);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/ToggleableInterface.php
+++ b/src/Symfony/Component/Tui/Widget/ToggleableInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+/**
+ * Interface for widgets that can be expanded or collapsed.
+ *
+ * @experimental
+ */
+interface ToggleableInterface
+{
+    /**
+     * Toggle between expanded and collapsed state.
+     */
+    public function toggle(): void;
+
+    /**
+     * Set the expanded state explicitly.
+     */
+    public function setExpanded(bool $expanded): void;
+
+    /**
+     * Whether the widget is currently expanded.
+     */
+    public function isExpanded(): bool;
+}


### PR DESCRIPTION
## Summary

Adds a `CollapsibleWidget` that shows a configurable number of preview lines when collapsed, with a hint indicating how many lines are hidden. When expanded, all content is shown.

This is a common pattern in terminal UIs — tool output, file contents, debug info — where showing everything at once creates too much noise. KosmoKrator (an AI coding agent built on Symfony TUI) needed this for collapsible tool results and had to build it from scratch.

### New files

- **`Widget/ToggleableInterface.php`** — `toggle()`, `setExpanded(bool)`, `isExpanded()` contract
- **`Widget/CollapsibleWidget.php`** — configurable header, preview line count, ANSI-safe truncation
  - `toggleAll(ContainerWidget)` static helper for recursive bulk toggle
  - Style sub-elements: `::header` (bold), `::hint` (dim)

### Usage

```php
$widget = new CollapsibleWidget(
    content: $longOutput,
    header: 'Command output',
    previewLines: 3,
);
$tui->add($widget);

// Later: expand/collapse
$widget->toggle();

// Bulk toggle all collapsibles in a container
CollapsibleWidget::toggleAll($container);
```

## Test plan

- [x] Collapsed render shows N preview lines + "▸ +M more lines" hint
- [x] Expanded render shows all lines
- [x] `toggle()` flips state, `setExpanded()` is idempotent
- [x] `toggleAll()` recurses through nested ContainerWidgets
- [x] Long lines truncated to terminal width
- [x] ANSI escape codes preserved through rendering
- [x] Empty content / header-only edge cases
- [x] Singular vs plural hint text ("line" vs "lines")