### PR TITLE
[Tui] Add modal/dialog system with blocking and non-blocking APIs

### DIFF
--- a/src/Symfony/Component/Tui/Event/ModalResolveEvent.php
+++ b/src/Symfony/Component/Tui/Event/ModalResolveEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Event;
+
+use Symfony\Component\Tui\Widget\AbstractWidget;
+
+/**
+ * Dispatched by a modal widget to resolve a blocking modal() call with a typed result.
+ *
+ * @experimental
+ */
+class ModalResolveEvent extends AbstractEvent
+{
+    public function __construct(
+        AbstractWidget $target,
+        private readonly mixed $result,
+    ) {
+        parent::__construct($target);
+    }
+
+    public function getResult(): mixed
+    {
+        return $this->result;
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/ModalTest.php
+++ b/src/Symfony/Component/Tui/Tests/ModalTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Terminal\VirtualTerminal;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\InputWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+class ModalTest extends TestCase
+{
+    public function testAddOverlayRendersWidget()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+
+        $tui->add(new TextWidget('Main content'));
+        $tui->start();
+        $tui->processRender();
+
+        $overlay = new TextWidget('Overlay dialog');
+        $tui->addOverlay($overlay);
+        $tui->processRender();
+
+        $output = $terminal->getOutput();
+        $this->assertStringContainsString('Main content', $output);
+        $this->assertStringContainsString('Overlay dialog', $output);
+
+        $tui->stop();
+    }
+
+    public function testRemoveOverlayRemovesWidget()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+
+        $tui->add(new TextWidget('Main content'));
+        $tui->start();
+
+        $overlay = new TextWidget('Overlay dialog');
+        $tui->addOverlay($overlay);
+        $tui->processRender();
+        $this->assertStringContainsString('Overlay dialog', $terminal->getOutput());
+
+        $terminal->clearOutput();
+        $tui->removeOverlay($overlay);
+        $tui->processRender();
+
+        $output = $terminal->getOutput();
+        $this->assertStringContainsString('Main content', $output);
+        $this->assertStringNotContainsString('Overlay dialog', $output);
+
+        $tui->stop();
+    }
+
+    public function testOverlayContainerAutoCleanup()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $tui->start();
+
+        $overlay = new TextWidget('Temporary');
+        $tui->addOverlay($overlay);
+
+        // The overlay container should exist
+        $found = $tui->getById('__tui_overlay');
+        $this->assertNotNull($found);
+
+        // Remove the overlay widget
+        $tui->removeOverlay($overlay);
+
+        // The overlay container should be removed from the root tree
+        $this->expectException(\Symfony\Component\Tui\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No widget found with id "__tui_overlay"');
+        $tui->getById('__tui_overlay');
+    }
+
+    public function testAddOverlaySetsFocus()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+
+        $mainInput = new InputWidget();
+        $tui->add($mainInput);
+        $tui->setFocus($mainInput);
+        $this->assertSame($mainInput, $tui->getFocus());
+
+        $tui->start();
+
+        // Add a focusable overlay widget
+        $overlayInput = new InputWidget();
+        $tui->addOverlay($overlayInput);
+
+        // Focus should move to the overlay widget
+        $this->assertSame($overlayInput, $tui->getFocus());
+
+        $tui->stop();
+    }
+
+    public function testRemoveOverlayIsNoOpWithoutOverlayContainer()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $tui->start();
+
+        // Removing an overlay when none were ever added should not throw
+        $tui->removeOverlay(new TextWidget('Never added'));
+
+        // Verify the TUI is still functional
+        $this->assertTrue($tui->isRunning());
+
+        $tui->stop();
+    }
+
+    public function testMultipleOverlayWidgets()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $tui->start();
+
+        $overlay1 = new TextWidget('First overlay');
+        $overlay2 = new TextWidget('Second overlay');
+        $tui->addOverlay($overlay1);
+        $tui->addOverlay($overlay2);
+        $tui->processRender();
+
+        $output = $terminal->getOutput();
+        $this->assertStringContainsString('First overlay', $output);
+        $this->assertStringContainsString('Second overlay', $output);
+
+        // Removing one should keep the other
+        $terminal->clearOutput();
+        $tui->removeOverlay($overlay1);
+        $tui->processRender();
+
+        $output = $terminal->getOutput();
+        $this->assertStringContainsString('Second overlay', $output);
+        $this->assertStringNotContainsString('First overlay', $output);
+
+        // Overlay container should still exist
+        $found = $tui->getById('__tui_overlay');
+        $this->assertNotNull($found);
+
+        // Removing the last one should clean up the container
+        $tui->removeOverlay($overlay2);
+
+        $this->expectException(\Symfony\Component\Tui\Exception\InvalidArgumentException::class);
+        $tui->getById('__tui_overlay');
+    }
+}

--- a/src/Symfony/Component/Tui/Tui.php
+++ b/src/Symfony/Component/Tui/Tui.php
@@ -16,7 +16,10 @@ use Revolt\EventLoop\Suspension;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Tui\Event\AbstractEvent;
+use Symfony\Component\Tui\Event\CancelEvent;
 use Symfony\Component\Tui\Event\InputEvent;
+use Symfony\Component\Tui\Event\ModalResolveEvent;
+use Symfony\Component\Tui\Event\SubmitEvent;
 use Symfony\Component\Tui\Event\TickEvent;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Focus\FocusManager;
@@ -81,6 +84,8 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
 
     /** @var Suspension<mixed>|null */
     private ?Suspension $runSuspension = null;
+
+    private ?ContainerWidget $overlayContainer = null;
 
     public function __construct(
         ?StyleSheet $styleSheet = null,
@@ -411,6 +416,111 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
     }
 
     /**
+     * Show a widget as a blocking modal dialog.
+     *
+     * The widget is added to an overlay container (rendered after the main content).
+     * Focus is automatically captured and restored. The method blocks via Revolt
+     * Suspension until the widget dispatches one of:
+     * - ModalResolveEvent: returns getResult() (any type)
+     * - SubmitEvent: returns getValue() (string)
+     * - CancelEvent: returns null
+     *
+     * @experimental
+     */
+    public function modal(AbstractWidget $widget): mixed
+    {
+        $previousFocus = $this->getFocus();
+        $overlay = $this->getOrCreateOverlay();
+        $overlay->add($widget);
+
+        if ($widget instanceof FocusableInterface) {
+            $this->setFocus($widget);
+        }
+
+        $this->processRender();
+
+        $suspension = EventLoop::getSuspension();
+        $resolved = false;
+
+        $widget->on(ModalResolveEvent::class, function (ModalResolveEvent $event) use ($suspension, &$resolved) {
+            if (!$resolved) {
+                $resolved = true;
+                $suspension->resume($event->getResult());
+            }
+        });
+
+        $widget->on(SubmitEvent::class, function (SubmitEvent $event) use ($suspension, &$resolved) {
+            if (!$resolved) {
+                $resolved = true;
+                $suspension->resume($event->getValue());
+            }
+        });
+
+        $widget->on(CancelEvent::class, function () use ($suspension, &$resolved) {
+            if (!$resolved) {
+                $resolved = true;
+                $suspension->resume(null);
+            }
+        });
+
+        $result = $suspension->suspend();
+
+        // Cleanup
+        $overlay->remove($widget);
+        $this->setFocus($previousFocus);
+
+        if ([] === $overlay->all()) {
+            $this->root->remove($overlay);
+            $this->overlayContainer = null;
+        }
+
+        $this->requestRender(true);
+        $this->processRender();
+
+        return $result;
+    }
+
+    /**
+     * Add a widget as a non-blocking overlay.
+     *
+     * The widget is rendered after the main content. Use removeOverlay() to dismiss.
+     *
+     * @experimental
+     */
+    public function addOverlay(AbstractWidget $widget): void
+    {
+        $this->getOrCreateOverlay()->add($widget);
+
+        if ($widget instanceof FocusableInterface) {
+            $this->setFocus($widget);
+        }
+
+        $this->requestRender();
+    }
+
+    /**
+     * Remove a non-blocking overlay widget.
+     *
+     * @experimental
+     */
+    public function removeOverlay(AbstractWidget $widget): void
+    {
+        $overlay = $this->overlayContainer;
+        if (null === $overlay) {
+            return;
+        }
+
+        $overlay->remove($widget);
+
+        if ([] === $overlay->all()) {
+            $this->root->remove($overlay);
+            $this->overlayContainer = null;
+        }
+
+        $this->requestRender(true);
+    }
+
+    /**
      * Schedule a repeating callback in the internal TUI scheduler.
      *
      * @internal
@@ -512,5 +622,16 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
         $suspension = $this->runSuspension;
         $this->runSuspension = null;
         $suspension->resume(null);
+    }
+
+    private function getOrCreateOverlay(): ContainerWidget
+    {
+        if (null === $this->overlayContainer) {
+            $this->overlayContainer = new ContainerWidget();
+            $this->overlayContainer->setId('__tui_overlay');
+            $this->root->add($this->overlayContainer);
+        }
+
+        return $this->overlayContainer;
     }
 }


### PR DESCRIPTION
## Summary

Adds a modal/dialog system to `Tui` with both blocking and non-blocking APIs. This eliminates the boilerplate of managing overlay containers, focus save/restore, and Revolt suspensions that every application currently has to implement manually.

KosmoKrator (an AI coding agent built on Symfony TUI) has a 520-line `TuiModalManager` that repeats the same suspension+overlay pattern across 7 modal types (permission prompts, settings panels, plan approval, etc.). This PR extracts the core pattern into the framework.

### New files

- **`Event/ModalResolveEvent.php`** — event carrying a `mixed $result`, allowing modals to resolve with any type (not just `SubmitEvent`'s string)

### Modified files

- **`Tui.php`** — three new public methods:
  - `modal(AbstractWidget $widget): mixed` — blocking API. Adds widget to overlay, captures focus, suspends via Revolt until the widget dispatches `ModalResolveEvent`, `SubmitEvent`, or `CancelEvent`. Returns the result or null.
  - `addOverlay(AbstractWidget $widget): void` — non-blocking overlay management
  - `removeOverlay(AbstractWidget $widget): void` — removes overlay, auto-cleans container

### Architecture note

The overlay container is added as the last child of the root `ContainerWidget`, rendering below the main content (bottom-sheet style). True z-layer rendering (drawing over existing content) would require changes to the `Renderer` and `ScreenWriter` — a candidate for a future PR.

### Usage

```php
// Blocking modal — suspends until user responds
$result = $tui->modal($confirmationWidget);

// Non-blocking overlay
$tui->addOverlay($statusWidget);
// ... later
$tui->removeOverlay($statusWidget);
```

## Test plan

- [x] `addOverlay()` renders widget in terminal output
- [x] `removeOverlay()` removes widget from output
- [x] Overlay container auto-cleaned when last widget removed
- [x] Focusable overlay widgets receive focus automatically
- [x] Multiple overlays coexist correctly
- [x] `removeOverlay()` is safe when no overlays exist