### PR TITLE
[Tui] Add AutocompleteWidget for input with completion overlay

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/AutocompleteTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/AutocompleteTest.php
@@ -1,0 +1,378 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Widget;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Event\CancelEvent;
+use Symfony\Component\Tui\Event\ChangeEvent;
+use Symfony\Component\Tui\Event\SelectEvent;
+use Symfony\Component\Tui\Event\SubmitEvent;
+use Symfony\Component\Tui\Terminal\VirtualTerminal;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\AutocompleteWidget;
+use Symfony\Component\Tui\Widget\FocusableInterface;
+use Symfony\Component\Tui\Widget\InputWidget;
+use Symfony\Component\Tui\Widget\ParentInterface;
+use Symfony\Component\Tui\Widget\SelectListWidget;
+
+class AutocompleteTest extends TestCase
+{
+    public function testImplementsInterfaces()
+    {
+        $widget = $this->createWidget();
+
+        $this->assertInstanceOf(FocusableInterface::class, $widget);
+        $this->assertInstanceOf(ParentInterface::class, $widget);
+    }
+
+    public function testAllReturnsInnerWidgets()
+    {
+        $widget = $this->createWidget();
+        $children = $widget->all();
+
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(InputWidget::class, $children[0]);
+        $this->assertInstanceOf(SelectListWidget::class, $children[1]);
+    }
+
+    public function testSetValueDelegatesToInput()
+    {
+        $widget = $this->createWidget();
+
+        $widget->setValue('hello');
+        $this->assertSame('hello', $widget->getValue());
+
+        $widget->setValue('');
+        $this->assertSame('', $widget->getValue());
+    }
+
+    public function testGetInputWidgetReturnsInnerInput()
+    {
+        $widget = $this->createWidget();
+
+        $this->assertInstanceOf(InputWidget::class, $widget->getInputWidget());
+        $this->assertSame($widget->all()[0], $widget->getInputWidget());
+    }
+
+    public function testTypingUpdatesValue()
+    {
+        $widget = $this->createWidget();
+
+        $widget->handleInput('h');
+        $widget->handleInput('e');
+
+        $this->assertSame('he', $widget->getValue());
+    }
+
+    public function testOverlayAppearsOnTyping()
+    {
+        [$widget] = $this->createWidgetWithTui();
+
+        $this->assertFalse($widget->isOverlayVisible());
+
+        // Type 'o' - matches 'opt1', 'opt2', 'opt3'
+        $widget->handleInput('o');
+
+        $this->assertTrue($widget->isOverlayVisible());
+    }
+
+    public function testEmptyInputHidesOverlay()
+    {
+        [$widget] = $this->createWidgetWithTui();
+
+        // Type to show overlay
+        $widget->handleInput('o');
+        $this->assertTrue($widget->isOverlayVisible());
+
+        // Backspace to empty
+        $widget->handleInput("\x7f");
+        $this->assertFalse($widget->isOverlayVisible());
+    }
+
+    public function testNoMatchesHidesOverlay()
+    {
+        [$widget] = $this->createWidgetWithTui();
+
+        // Type something that matches nothing
+        $widget->handleInput('z');
+        $widget->handleInput('z');
+        $widget->handleInput('z');
+
+        $this->assertFalse($widget->isOverlayVisible());
+    }
+
+    public function testTriggerPrefix()
+    {
+        [$widget] = $this->createWidgetWithTui([
+            ['value' => 'help', 'label' => 'Help'],
+            ['value' => 'quit', 'label' => 'Quit'],
+        ], '/');
+
+        // Type without trigger - overlay should stay hidden
+        $widget->handleInput('h');
+        $this->assertFalse($widget->isOverlayVisible());
+
+        // Clear and type with trigger
+        $widget->handleInput("\x15"); // Ctrl+U (delete to line start)
+        $widget->handleInput('/');
+        $this->assertTrue($widget->isOverlayVisible());
+    }
+
+    public function testTriggerPrefixFiltersAfterTrigger()
+    {
+        [$widget] = $this->createWidgetWithTui([
+            ['value' => 'help', 'label' => 'Help'],
+            ['value' => 'quit', 'label' => 'Quit'],
+        ], '/');
+
+        // Type /q - should show overlay with 'quit' matching
+        $widget->handleInput('/');
+        $widget->handleInput('q');
+
+        $this->assertTrue($widget->isOverlayVisible());
+
+        // Type /qz - should hide, no match
+        $widget->handleInput('z');
+
+        $this->assertFalse($widget->isOverlayVisible());
+    }
+
+    public function testCustomFilter()
+    {
+        $items = [
+            ['value' => 'apple', 'label' => 'Apple'],
+            ['value' => 'banana', 'label' => 'Banana'],
+            ['value' => 'cherry', 'label' => 'Cherry'],
+        ];
+
+        // Custom filter: substring match on label (not just prefix)
+        [$widget] = $this->createWidgetWithTui($items, null, static fn (array $item, string $query) => '' === $query || str_contains(strtolower($item['label']), strtolower($query)));
+
+        // Type 'an' - should match 'Banana' (contains 'an') via substring
+        $widget->handleInput('a');
+        $widget->handleInput('n');
+
+        // With default prefix filter, 'an' wouldn't match 'banana' or 'cherry'
+        // but 'apple' would match. With our substring filter, 'banana' also matches.
+        $this->assertTrue($widget->isOverlayVisible());
+    }
+
+    public function testEscapeDismissesOverlay()
+    {
+        [$widget] = $this->createWidgetWithTui();
+
+        $widget->handleInput('o');
+        $this->assertTrue($widget->isOverlayVisible());
+
+        // Press escape
+        $widget->handleInput("\x1b");
+
+        $this->assertFalse($widget->isOverlayVisible());
+        // Value is preserved
+        $this->assertSame('o', $widget->getValue());
+    }
+
+    public function testArrowKeysNavigateOverlay()
+    {
+        [$widget] = $this->createWidgetWithTui();
+
+        $widget->handleInput('o');
+        $this->assertTrue($widget->isOverlayVisible());
+
+        // Down arrow - should navigate list, not modify input
+        $widget->handleInput("\x1b[B");
+
+        // Value should still be 'o' (not changed by list navigation)
+        $this->assertSame('o', $widget->getValue());
+    }
+
+    public function testEnterSelectsItemFromOverlay()
+    {
+        [$widget, $tui] = $this->createWidgetWithTui();
+
+        $selectedItem = null;
+        $tui->on(SelectEvent::class, static function (SelectEvent $e) use (&$selectedItem) {
+            $selectedItem = $e->getItem();
+        });
+
+        // Type to show overlay, then select
+        $widget->handleInput('o');
+        $this->assertTrue($widget->isOverlayVisible());
+
+        // Press enter to select first item
+        $widget->handleInput("\r");
+
+        $this->assertNotNull($selectedItem);
+        $this->assertSame('opt1', $selectedItem['value']);
+        $this->assertFalse($widget->isOverlayVisible());
+        // Input cleared after selection
+        $this->assertSame('', $widget->getValue());
+    }
+
+    public function testTabFillsInputWithSelectedValue()
+    {
+        [$widget] = $this->createWidgetWithTui();
+
+        $widget->handleInput('o');
+        $this->assertTrue($widget->isOverlayVisible());
+
+        // Press tab to fill
+        $widget->handleInput("\t");
+
+        $this->assertFalse($widget->isOverlayVisible());
+        $this->assertSame('opt1', $widget->getValue());
+    }
+
+    public function testSubmitDelegatesWhenOverlayHidden()
+    {
+        [$widget, $tui] = $this->createWidgetWithTui();
+
+        $submittedValue = null;
+        $tui->on(SubmitEvent::class, static function (SubmitEvent $e) use (&$submittedValue) {
+            $submittedValue = $e->getValue();
+        });
+
+        // Type something that doesn't match, so overlay is hidden
+        $widget->handleInput('z');
+        $widget->handleInput('z');
+        $this->assertFalse($widget->isOverlayVisible());
+
+        // Press enter - should submit
+        $widget->handleInput("\r");
+
+        $this->assertSame('zz', $submittedValue);
+    }
+
+    public function testCancelDelegatesWhenOverlayHidden()
+    {
+        [$widget, $tui] = $this->createWidgetWithTui();
+
+        $cancelled = false;
+        $tui->on(CancelEvent::class, static function () use (&$cancelled) {
+            $cancelled = true;
+        });
+
+        // No overlay
+        $this->assertFalse($widget->isOverlayVisible());
+
+        // Escape should cancel
+        $widget->handleInput("\x1b");
+
+        $this->assertTrue($cancelled);
+    }
+
+    public function testChangePropagates()
+    {
+        [$widget, $tui] = $this->createWidgetWithTui();
+
+        $changedValue = null;
+        $tui->on(ChangeEvent::class, static function (ChangeEvent $e) use (&$changedValue) {
+            $changedValue = $e->getValue();
+        });
+
+        $widget->handleInput('x');
+
+        $this->assertSame('x', $changedValue);
+    }
+
+    public function testFocusable()
+    {
+        $widget = $this->createWidget();
+
+        $this->assertFalse($widget->isFocused());
+
+        $widget->setFocused(true);
+        $this->assertTrue($widget->isFocused());
+
+        $widget->setFocused(false);
+        $this->assertFalse($widget->isFocused());
+    }
+
+    public function testOnInputCallbackConsumesEvent()
+    {
+        $widget = $this->createWidget();
+
+        $intercepted = false;
+        $widget->onInput(static function (string $data) use (&$intercepted): bool {
+            if ('x' === $data) {
+                $intercepted = true;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        $widget->handleInput('x');
+        $this->assertTrue($intercepted);
+        $this->assertSame('', $widget->getValue(), 'Consumed input should not be typed');
+    }
+
+    public function testSetItemsUpdatesCompletions()
+    {
+        [$widget] = $this->createWidgetWithTui();
+
+        // Type 'n' - no match in original items
+        $widget->handleInput('n');
+        $this->assertFalse($widget->isOverlayVisible());
+
+        // Update items with a matching one
+        $widget->setItems([
+            ['value' => 'new', 'label' => 'New Item'],
+        ]);
+
+        // Type another character to trigger re-evaluation
+        $widget->handleInput('e');
+
+        $this->assertTrue($widget->isOverlayVisible());
+    }
+
+    /**
+     * @return AutocompleteWidget
+     */
+    private function createWidget(): AutocompleteWidget
+    {
+        return new AutocompleteWidget($this->getTestItems());
+    }
+
+    /**
+     * @param array<array{value: string, label: string, description?: string}>|null $items
+     *
+     * @return array{AutocompleteWidget, Tui}
+     */
+    private function createWidgetWithTui(?array $items = null, ?string $trigger = null, ?callable $filter = null): array
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+        $widget = new AutocompleteWidget($items ?? $this->getTestItems(), $trigger);
+
+        if (null !== $filter) {
+            $widget->setFilter($filter);
+        }
+
+        $tui->add($widget);
+
+        return [$widget, $tui];
+    }
+
+    /**
+     * @return array<array{value: string, label: string, description?: string}>
+     */
+    private function getTestItems(): array
+    {
+        return [
+            ['value' => 'opt1', 'label' => 'Option 1', 'description' => 'First option'],
+            ['value' => 'opt2', 'label' => 'Option 2', 'description' => 'Second option'],
+            ['value' => 'opt3', 'label' => 'Option 3', 'description' => 'Third option'],
+        ];
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/AutocompleteWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AutocompleteWidget.php
@@ -1,0 +1,335 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+use Symfony\Component\Tui\Event\CancelEvent;
+use Symfony\Component\Tui\Event\ChangeEvent;
+use Symfony\Component\Tui\Event\SelectEvent;
+use Symfony\Component\Tui\Event\SubmitEvent;
+use Symfony\Component\Tui\Input\Key;
+use Symfony\Component\Tui\Render\RenderContext;
+
+/**
+ * Input widget with autocomplete overlay.
+ *
+ * Composes an InputWidget for text editing and a SelectListWidget for
+ * completion suggestions. The overlay appears when input matches the
+ * trigger prefix and disappears on selection, cancellation, or when
+ * no items match the filter.
+ *
+ * Keyboard behavior when overlay is visible:
+ * - Up/Down: navigate suggestions
+ * - Enter: select the highlighted suggestion
+ * - Tab: fill input with highlighted value without selecting
+ * - Escape: dismiss overlay
+ *
+ * @experimental
+ */
+class AutocompleteWidget extends AbstractWidget implements FocusableInterface, ParentInterface
+{
+    use FocusableTrait;
+    use KeybindingsTrait;
+
+    private InputWidget $input;
+    private SelectListWidget $list;
+    private bool $overlayVisible = false;
+
+    /** @var array<array{value: string, label: string, description?: string}> */
+    private array $items = [];
+
+    private ?string $trigger = null;
+    private ?\Closure $filterFn = null;
+
+    /**
+     * @param array<array{value: string, label: string, description?: string}> $items
+     * @param string|null $trigger Prefix that activates the overlay (e.g. "/"). Null = always active.
+     */
+    public function __construct(
+        array $items = [],
+        ?string $trigger = null,
+    ) {
+        $this->items = $items;
+        $this->trigger = $trigger;
+        $this->input = new InputWidget();
+        $this->list = new SelectListWidget($items);
+
+        $this->wireInputEvents();
+    }
+
+    /**
+     * @param array<array{value: string, label: string, description?: string}> $items
+     */
+    public function setItems(array $items): static
+    {
+        $this->items = $items;
+        $this->invalidate();
+
+        return $this;
+    }
+
+    public function setTrigger(?string $trigger): static
+    {
+        $this->trigger = $trigger;
+
+        return $this;
+    }
+
+    /**
+     * Set a custom filter function.
+     *
+     * The callable receives (array $item, string $query) and should return bool.
+     * Default: prefix match on the item value.
+     */
+    public function setFilter(?callable $filter): static
+    {
+        $this->filterFn = null !== $filter ? $filter(...) : null;
+
+        return $this;
+    }
+
+    public function setPrompt(string $prompt): static
+    {
+        $this->input->setPrompt($prompt);
+
+        return $this;
+    }
+
+    public function setValue(string $value): static
+    {
+        $this->input->setValue($value);
+
+        return $this;
+    }
+
+    public function getValue(): string
+    {
+        return $this->input->getValue();
+    }
+
+    public function getInputWidget(): InputWidget
+    {
+        return $this->input;
+    }
+
+    public function isOverlayVisible(): bool
+    {
+        return $this->overlayVisible;
+    }
+
+    // Event convenience methods
+
+    public function onSelect(callable $callback): static
+    {
+        return $this->on(SelectEvent::class, $callback);
+    }
+
+    public function onSubmit(callable $callback): static
+    {
+        return $this->on(SubmitEvent::class, $callback);
+    }
+
+    public function onCancel(callable $callback): static
+    {
+        return $this->on(CancelEvent::class, $callback);
+    }
+
+    public function onChange(callable $callback): static
+    {
+        return $this->on(ChangeEvent::class, $callback);
+    }
+
+    public function handleInput(string $data): void
+    {
+        if (null !== $this->onInput && ($this->onInput)($data)) {
+            return;
+        }
+
+        // When overlay is visible, intercept navigation keys
+        if ($this->overlayVisible) {
+            $kb = $this->getKeybindings();
+
+            // Arrow keys navigate the list
+            if ($kb->matches($data, 'overlay_up') || $kb->matches($data, 'overlay_down')) {
+                $this->list->handleInput($data);
+                $this->invalidate();
+
+                return;
+            }
+
+            // Enter selects the highlighted item
+            if ($kb->matches($data, 'overlay_select')) {
+                $selected = $this->list->getSelectedItem();
+                if (null !== $selected) {
+                    $this->input->setValue('');
+                    $this->hideOverlay();
+                    $this->dispatch(new SelectEvent($this->list, $selected));
+
+                    return;
+                }
+            }
+
+            // Tab fills input with selected value
+            if ($kb->matches($data, 'overlay_fill')) {
+                $selected = $this->list->getSelectedItem();
+                if (null !== $selected) {
+                    $this->input->setValue($selected['value']);
+                }
+                $this->hideOverlay();
+
+                return;
+            }
+
+            // Escape dismisses overlay
+            if ($kb->matches($data, 'overlay_dismiss')) {
+                $this->hideOverlay();
+
+                return;
+            }
+        }
+
+        // Delegate all other input to the inner InputWidget
+        $this->input->handleInput($data);
+    }
+
+    /**
+     * @return AbstractWidget[]
+     */
+    public function all(): array
+    {
+        return [$this->input, $this->list];
+    }
+
+    public function render(RenderContext $context): array
+    {
+        $ctx = $this->getContext();
+        if (null === $ctx) {
+            return [];
+        }
+
+        $lines = $ctx->renderWidget($this->input, $context);
+
+        if ($this->overlayVisible) {
+            $listLines = $ctx->renderWidget($this->list, $context);
+            array_push($lines, ...$listLines);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    protected static function getDefaultKeybindings(): array
+    {
+        return [
+            'overlay_up' => [Key::UP],
+            'overlay_down' => [Key::DOWN],
+            'overlay_select' => [Key::ENTER],
+            'overlay_fill' => [Key::TAB],
+            'overlay_dismiss' => [Key::ESCAPE],
+        ];
+    }
+
+    private function wireInputEvents(): void
+    {
+        // Track text changes to show/hide overlay
+        $this->input->on(ChangeEvent::class, function (ChangeEvent $event) {
+            $this->updateOverlayVisibility($event->getValue());
+            $this->dispatch(new ChangeEvent($this, $event->getValue()));
+        });
+
+        // Re-dispatch submit/cancel from inner input
+        $this->input->on(SubmitEvent::class, function (SubmitEvent $event) {
+            if (!$this->overlayVisible) {
+                $this->dispatch(new SubmitEvent($this, $event->getValue()));
+            }
+        });
+
+        $this->input->on(CancelEvent::class, function () {
+            if (!$this->overlayVisible) {
+                $this->dispatch(new CancelEvent($this));
+            }
+        });
+    }
+
+    private function updateOverlayVisibility(string $value): void
+    {
+        if (!$this->shouldShowOverlay($value)) {
+            $this->hideOverlay();
+
+            return;
+        }
+
+        $filtered = $this->filterItems($value);
+        if ([] !== $filtered) {
+            $this->list->setItems($filtered);
+            $this->showOverlay();
+        } else {
+            $this->hideOverlay();
+        }
+    }
+
+    private function shouldShowOverlay(string $value): bool
+    {
+        if ('' === $value) {
+            return false;
+        }
+
+        if (null === $this->trigger) {
+            return true;
+        }
+
+        return str_starts_with($value, $this->trigger);
+    }
+
+    /**
+     * @return array<array{value: string, label: string, description?: string}>
+     */
+    private function filterItems(string $value): array
+    {
+        $query = $value;
+        if (null !== $this->trigger) {
+            $query = substr($value, \strlen($this->trigger));
+        }
+
+        if (null !== $this->filterFn) {
+            return array_values(array_filter(
+                $this->items,
+                fn (array $item) => ($this->filterFn)($item, $query),
+            ));
+        }
+
+        // Default: prefix match on value (case-insensitive)
+        $lower = strtolower($query);
+
+        return array_values(array_filter(
+            $this->items,
+            static fn (array $item) => '' === $lower || str_starts_with(strtolower($item['value']), $lower),
+        ));
+    }
+
+    private function showOverlay(): void
+    {
+        if (!$this->overlayVisible) {
+            $this->overlayVisible = true;
+            $this->invalidate();
+        }
+    }
+
+    private function hideOverlay(): void
+    {
+        if ($this->overlayVisible) {
+            $this->overlayVisible = false;
+            $this->invalidate();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an `AutocompleteWidget` that composes `InputWidget` + `SelectListWidget` to provide input-with-completion functionality — a pattern needed by any TUI application with command palettes, slash commands, or searchable pickers.

KosmoKrator (an AI coding agent built on Symfony TUI) had ~100 lines of glue code spread across its renderer to manage a `SelectListWidget` overlay for `/` slash command completion. This PR extracts that pattern into a reusable widget.

### Design: composition over inheritance

Rather than extending `InputWidget` (already 451 lines), the widget composes both widgets and delegates rendering via `WidgetContext::renderWidget()`. It implements `ParentInterface` so the inner widgets get proper `WidgetContext` attachment via `WidgetTree` traversal.

### Features

- **Trigger prefix** — optional activation prefix (e.g. `"/"` for slash commands). `null` = always active.
- **Custom filter** — pluggable filter function. Default: case-insensitive prefix match.
- **Keyboard handling** when overlay visible:
  - Up/Down: navigate suggestions
  - Enter: select highlighted item (dispatches `SelectEvent`)
  - Tab: fill input with highlighted value without selecting
  - Escape: dismiss overlay
- **Event propagation** — `ChangeEvent`, `SubmitEvent`, `CancelEvent` re-dispatched from inner `InputWidget`

### Usage

```php
$autocomplete = new AutocompleteWidget(
    items: [
        ['value' => '/edit', 'label' => '/edit', 'description' => 'Switch to edit mode'],
        ['value' => '/plan', 'label' => '/plan', 'description' => 'Switch to plan mode'],
        ['value' => '/quit', 'label' => '/quit', 'description' => 'Exit'],
    ],
    trigger: '/',
);

$autocomplete->onSelect(function (SelectEvent $event) {
    echo 'Selected: '.$event->getValue();
});

$tui->add($autocomplete);
```

## Test plan

- [x] Implements `FocusableInterface` and `ParentInterface`
- [x] `all()` returns both inner widgets
- [x] `setValue()`/`getValue()` delegates to inner `InputWidget`
- [x] Typing triggers overlay with filtered items
- [x] Empty input hides overlay
- [x] No matches hides overlay
- [x] Trigger prefix: overlay only activates after prefix
- [x] Custom filter function applied correctly
- [x] Escape dismisses overlay
- [x] Arrow keys navigate list
- [x] Enter selects and dispatches `SelectEvent`
- [x] Tab fills input without selecting
- [x] Submit/Cancel delegated when overlay hidden
- [x] Change events propagated
- [x] Dynamic item updates work
- [x] 21 tests total, all passing